### PR TITLE
feat: add multi-tenancy spaces support

### DIFF
--- a/files/migrations/000012_multi_tenancy_spaces.down.sql
+++ b/files/migrations/000012_multi_tenancy_spaces.down.sql
@@ -1,0 +1,13 @@
+-- Revert users.role CHECK constraint
+ALTER TABLE users DROP CONSTRAINT users_role_check;
+ALTER TABLE users ADD CONSTRAINT users_role_check CHECK (role IN ('owner', 'admin', 'member', 'viewer'));
+
+-- Remove space_id from existing tables
+ALTER TABLE storage DROP COLUMN IF EXISTS space_id;
+ALTER TABLE invitation_uses DROP COLUMN IF EXISTS space_id;
+ALTER TABLE invitations DROP COLUMN IF EXISTS space_id;
+ALTER TABLE events DROP COLUMN IF EXISTS space_id;
+ALTER TABLE applications DROP COLUMN IF EXISTS space_id;
+
+-- Drop spaces table
+DROP TABLE IF EXISTS spaces;

--- a/files/migrations/000012_multi_tenancy_spaces.up.sql
+++ b/files/migrations/000012_multi_tenancy_spaces.up.sql
@@ -1,0 +1,20 @@
+-- Spaces table
+CREATE TABLE spaces (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    user_public_key TEXT REFERENCES users(public_key),
+    created_at BIGINT,
+    updated_at BIGINT
+);
+CREATE INDEX idx_spaces_user_public_key ON spaces(user_public_key);
+
+-- Add space_id to existing tables
+ALTER TABLE applications ADD COLUMN space_id TEXT REFERENCES spaces(id);
+ALTER TABLE events ADD COLUMN space_id TEXT REFERENCES spaces(id);
+ALTER TABLE invitations ADD COLUMN space_id TEXT REFERENCES spaces(id);
+ALTER TABLE invitation_uses ADD COLUMN space_id TEXT REFERENCES spaces(id);
+ALTER TABLE storage ADD COLUMN space_id TEXT REFERENCES spaces(id);
+
+-- Update users.role CHECK constraint to instance-level roles
+ALTER TABLE users DROP CONSTRAINT users_role_check;
+ALTER TABLE users ADD CONSTRAINT users_role_check CHECK (role IN ('owner', 'user', 'guest'));

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -10,6 +10,7 @@ type Application struct {
 	Name            string           `json:"name"`
 	Icon            *string          `json:"icon,omitempty"`
 	SpacePublicKey *string          `json:"spacePublicKey,omitempty"`
+	SpaceID         *string          `json:"spaceId,omitempty"`
 	CreatedAt       int64            `json:"createdAt"`
 	UpdatedAt       int64            `json:"updatedAt"`
 	DeletedAt       *int64           `json:"deletedAt,omitempty"`

--- a/internal/application/application_endpoints.go
+++ b/internal/application/application_endpoints.go
@@ -55,6 +55,11 @@ func (ae *ApplicationEndpoints) RegisterApplication(ctx *fasthttp.RequestCtx) {
 	// Set space public key for the application
 	app.SpacePublicKey = &ae.spacePublicKey
 
+	// Set space ID from authenticated user's JWT claims
+	if authenticatedUser.SpaceID != "" {
+		app.SpaceID = &authenticatedUser.SpaceID
+	}
+
 	// Register the application
 	_, err := ae.appService.RegisterApplication(authenticatedUser.PublicKey, &app)
 	if err != nil {

--- a/internal/application/repository.go
+++ b/internal/application/repository.go
@@ -16,26 +16,28 @@ func NewRepository(db *sql.DB) *Repository {
 }
 
 func (r *Repository) CreateApplication(app *Application) error {
-	query := `INSERT INTO applications (id, name, icon, space_public_key, created_at, updated_at)
-			  VALUES ($1, $2, $3, $4, $5, $6)
+	query := `INSERT INTO applications (id, name, icon, space_public_key, space_id, created_at, updated_at)
+			  VALUES ($1, $2, $3, $4, $5, $6, $7)
 			  ON CONFLICT (id) DO UPDATE SET
 			    name = EXCLUDED.name,
 			    icon = EXCLUDED.icon,
+			    space_id = EXCLUDED.space_id,
 			    updated_at = EXCLUDED.updated_at,
 			    deleted_at = NULL`
 
-	_, err := r.db.Exec(query, app.ID, app.Name, app.Icon, app.SpacePublicKey, app.CreatedAt, app.UpdatedAt)
+	_, err := r.db.Exec(query, app.ID, app.Name, app.Icon, app.SpacePublicKey, app.SpaceID, app.CreatedAt, app.UpdatedAt)
 	return err
 }
 
 func (r *Repository) GetApplicationByID(id string) (*Application, error) {
-	query := `SELECT id, name, icon, space_public_key, created_at, updated_at, last_sequence
+	query := `SELECT id, name, icon, space_public_key, space_id, created_at, updated_at, last_sequence
 			  FROM applications WHERE id = $1 AND deleted_at IS NULL`
 
 	app := &Application{}
 	var lastSequence sql.NullInt64
+	var spaceID sql.NullString
 	err := r.db.QueryRow(query, id).Scan(
-		&app.ID, &app.Name, &app.Icon, &app.SpacePublicKey, &app.CreatedAt, &app.UpdatedAt,
+		&app.ID, &app.Name, &app.Icon, &app.SpacePublicKey, &spaceID, &app.CreatedAt, &app.UpdatedAt,
 		&lastSequence,
 	)
 
@@ -48,6 +50,9 @@ func (r *Repository) GetApplicationByID(id string) (*Application, error) {
 
 	if lastSequence.Valid {
 		app.LastSequence = &lastSequence.Int64
+	}
+	if spaceID.Valid {
+		app.SpaceID = &spaceID.String
 	}
 
 	// Load component groups
@@ -632,7 +637,7 @@ func (r *Repository) GetMemberByPublicKey(appID, publicKey string) (*Member, err
 }
 
 func (r *Repository) GetApplicationsByMemberPublicKey(publicKey string) ([]*Application, error) {
-	query := `SELECT DISTINCT a.id, a.name, a.icon, a.space_public_key, a.created_at, a.updated_at, a.last_sequence
+	query := `SELECT DISTINCT a.id, a.name, a.icon, a.space_public_key, a.space_id, a.created_at, a.updated_at, a.last_sequence
 			  FROM applications a
 			  INNER JOIN members m ON a.id = m.application_id
 			  WHERE m.public_key = $1 AND a.deleted_at IS NULL
@@ -648,12 +653,16 @@ func (r *Repository) GetApplicationsByMemberPublicKey(publicKey string) ([]*Appl
 	for rows.Next() {
 		app := &Application{}
 		var lastSequence sql.NullInt64
-		err := rows.Scan(&app.ID, &app.Name, &app.Icon, &app.SpacePublicKey, &app.CreatedAt, &app.UpdatedAt, &lastSequence)
+		var spaceID sql.NullString
+		err := rows.Scan(&app.ID, &app.Name, &app.Icon, &app.SpacePublicKey, &spaceID, &app.CreatedAt, &app.UpdatedAt, &lastSequence)
 		if err != nil {
 			return nil, err
 		}
 		if lastSequence.Valid {
 			app.LastSequence = &lastSequence.Int64
+		}
+		if spaceID.Valid {
+			app.SpaceID = &spaceID.String
 		}
 
 		// Load component groups for this application

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -38,6 +38,7 @@ type Event struct {
 	CreatorPublicKey string                 `json:"creatorPublicKey"`
 	Version          int                    `json:"version"`
 	Data             map[string]interface{} `json:"data"`
+	SpaceID          string                 `json:"spaceId,omitempty"`
 }
 
 // MemberAddedData represents the data for a member_added event

--- a/internal/event/event_repository.go
+++ b/internal/event/event_repository.go
@@ -61,8 +61,13 @@ func (r *EventRepository) Create(event *Event) error {
 		appID = event.ApplicationID
 	}
 
-	query := `INSERT INTO events (id, created_at, application_id, sequence_number, type, creator_public_key, version, data)
-			  VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
+	var spaceIDVal interface{}
+	if event.SpaceID != "" {
+		spaceIDVal = event.SpaceID
+	}
+
+	query := `INSERT INTO events (id, created_at, application_id, sequence_number, type, creator_public_key, version, data, space_id)
+			  VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
 
 	_, err = r.db.Exec(query,
 		event.ID,
@@ -73,6 +78,7 @@ func (r *EventRepository) Create(event *Event) error {
 		event.CreatorPublicKey,
 		event.Version,
 		string(dataJSON),
+		spaceIDVal,
 	)
 
 	if err != nil {

--- a/internal/event/event_service.go
+++ b/internal/event/event_service.go
@@ -60,6 +60,9 @@ func (s *EventService) AcceptEvent(ctx context.Context, event *Event, submitter 
 	// Set ApplicationID field from data
 	event.ApplicationID = appID
 
+	// Set space ID from submitter's JWT claims
+	event.SpaceID = submitter.SpaceID
+
 	app, err := s.appRepo.GetApplicationByID(appID)
 	if err != nil {
 		return nil, fmt.Errorf("application not found: %w", err)
@@ -139,6 +142,9 @@ func (s *EventService) acceptUserScopedEvent(ctx context.Context, event *Event, 
 		return nil, fmt.Errorf("authorization failed: %w", err)
 	}
 	log.Debug().Str("eventId", event.ID).Msg("[EVENT] Authorization passed")
+
+	// Set space ID from submitter's JWT claims
+	event.SpaceID = submitter.SpaceID
 
 	// User-scoped events have no sequence number
 	event.SequenceNumber = 0

--- a/internal/http.go
+++ b/internal/http.go
@@ -7,16 +7,17 @@ import (
 	"github.com/prappser/prappser-spaces/internal/event"
 	"github.com/prappser/prappser-spaces/internal/health"
 	"github.com/prappser/prappser-spaces/internal/invitation"
-	"github.com/prappser/prappser-spaces/internal/storage"
 	"github.com/prappser/prappser-spaces/internal/middleware"
 	"github.com/prappser/prappser-spaces/internal/setup"
+	"github.com/prappser/prappser-spaces/internal/space"
 	"github.com/prappser/prappser-spaces/internal/status"
+	"github.com/prappser/prappser-spaces/internal/storage"
 	"github.com/prappser/prappser-spaces/internal/user"
 	"github.com/prappser/prappser-spaces/internal/websocket"
 	"github.com/valyala/fasthttp"
 )
 
-func NewRequestHandler(config *Config, userEndpoints *user.UserEndpoints, statusEndpoints *status.StatusEndpoints, healthEndpoints *health.HealthEndpoints, userService *user.UserService, appEndpoints *application.ApplicationEndpoints, invitationEndpoints *invitation.InvitationEndpoints, eventEndpoints *event.EventEndpoints, setupEndpoints *setup.SetupEndpoints, storageEndpoints *storage.Endpoints, wsHandler *websocket.Handler) fasthttp.RequestHandler {
+func NewRequestHandler(config *Config, userEndpoints *user.UserEndpoints, statusEndpoints *status.StatusEndpoints, healthEndpoints *health.HealthEndpoints, userService *user.UserService, appEndpoints *application.ApplicationEndpoints, invitationEndpoints *invitation.InvitationEndpoints, eventEndpoints *event.EventEndpoints, setupEndpoints *setup.SetupEndpoints, storageEndpoints *storage.Endpoints, wsHandler *websocket.Handler, spaceEndpoints *space.SpaceEndpoints) fasthttp.RequestHandler {
 	authMiddleware := middleware.NewAuthMiddleware(userService)
 	corsMiddleware := middleware.NewCORSMiddleware(config.AllowedOrigins)
 
@@ -27,7 +28,7 @@ func NewRequestHandler(config *Config, userEndpoints *user.UserEndpoints, status
 		case path == "/setup/railway":
 			method := string(ctx.Method())
 			if method == "POST" {
-				authMiddleware.RequireRole(user.RoleOwner, setupEndpoints.SetRailwayToken)(ctx)
+				authMiddleware.RequireRole(setupEndpoints.SetRailwayToken, user.RoleOwner)(ctx)
 			} else {
 				ctx.Error("Method Not Allowed", fasthttp.StatusMethodNotAllowed)
 			}
@@ -58,14 +59,14 @@ func NewRequestHandler(config *Config, userEndpoints *user.UserEndpoints, status
 			authMiddleware.RequireAuth(statusEndpoints.Status)(ctx)
 
 		case path == "/applications/register":
-			authMiddleware.RequireRole(user.RoleOwner, appEndpoints.RegisterApplication)(ctx)
+			authMiddleware.RequireRole(appEndpoints.RegisterApplication, user.RoleOwner, user.RoleUser)(ctx)
 		case path == "/applications":
-			authMiddleware.RequireRole(user.RoleOwner, appEndpoints.ListApplications)(ctx)
+			authMiddleware.RequireRole(appEndpoints.ListApplications, user.RoleOwner, user.RoleUser)(ctx)
 		case strings.HasPrefix(path, "/applications/") && strings.HasSuffix(path, "/state"):
 			parts := strings.Split(path, "/")
 			if len(parts) == 4 && parts[3] == "state" {
 				ctx.SetUserValue("appID", parts[2])
-				authMiddleware.RequireRole(user.RoleOwner, appEndpoints.GetApplicationState)(ctx)
+				authMiddleware.RequireRole(appEndpoints.GetApplicationState, user.RoleOwner, user.RoleUser)(ctx)
 			} else {
 				ctx.Error("Not Found", fasthttp.StatusNotFound)
 			}
@@ -78,9 +79,9 @@ func NewRequestHandler(config *Config, userEndpoints *user.UserEndpoints, status
 					method := string(ctx.Method())
 					switch method {
 					case "POST":
-						authMiddleware.RequireRole(user.RoleOwner, invitationEndpoints.CreateInvite)(ctx)
+						authMiddleware.RequireRole(invitationEndpoints.CreateInvite, user.RoleOwner, user.RoleUser)(ctx)
 					case "GET":
-						authMiddleware.RequireRole(user.RoleOwner, invitationEndpoints.ListInvites)(ctx)
+						authMiddleware.RequireRole(invitationEndpoints.ListInvites, user.RoleOwner, user.RoleUser)(ctx)
 					default:
 						ctx.Error("Method Not Allowed", fasthttp.StatusMethodNotAllowed)
 					}
@@ -88,7 +89,7 @@ func NewRequestHandler(config *Config, userEndpoints *user.UserEndpoints, status
 					ctx.SetUserValue("inviteID", parts[4])
 					method := string(ctx.Method())
 					if method == "DELETE" {
-						authMiddleware.RequireRole(user.RoleOwner, invitationEndpoints.RevokeInvite)(ctx)
+						authMiddleware.RequireRole(invitationEndpoints.RevokeInvite, user.RoleOwner, user.RoleUser)(ctx)
 					} else {
 						ctx.Error("Method Not Allowed", fasthttp.StatusMethodNotAllowed)
 					}
@@ -120,7 +121,7 @@ func NewRequestHandler(config *Config, userEndpoints *user.UserEndpoints, status
 				case "GET":
 					authMiddleware.RequireAuth(appEndpoints.GetApplication)(ctx)
 				case "DELETE":
-					authMiddleware.RequireRole(user.RoleOwner, appEndpoints.DeleteApplication)(ctx)
+					authMiddleware.RequireRole(appEndpoints.DeleteApplication, user.RoleOwner, user.RoleUser)(ctx)
 				default:
 					ctx.Error("Method Not Allowed", fasthttp.StatusMethodNotAllowed)
 				}
@@ -235,6 +236,57 @@ func NewRequestHandler(config *Config, userEndpoints *user.UserEndpoints, status
 
 		case path == "/ws":
 			wsHandler.HandleFastHTTP(ctx)
+
+		case path == "/spaces/mine":
+			method := string(ctx.Method())
+			if method == "GET" {
+				authMiddleware.RequireAuth(spaceEndpoints.GetMySpace)(ctx)
+			} else {
+				ctx.Error("Method Not Allowed", fasthttp.StatusMethodNotAllowed)
+			}
+		case path == "/spaces/claim":
+			method := string(ctx.Method())
+			if method == "POST" {
+				authMiddleware.RequireAuth(spaceEndpoints.ClaimSpace)(ctx)
+			} else {
+				ctx.Error("Method Not Allowed", fasthttp.StatusMethodNotAllowed)
+			}
+		case path == "/spaces":
+			method := string(ctx.Method())
+			switch method {
+			case "GET":
+				authMiddleware.RequireRole(spaceEndpoints.ListSpaces, user.RoleOwner)(ctx)
+			case "POST":
+				authMiddleware.RequireRole(spaceEndpoints.CreateSpace, user.RoleOwner)(ctx)
+			default:
+				ctx.Error("Method Not Allowed", fasthttp.StatusMethodNotAllowed)
+			}
+		case strings.HasPrefix(path, "/spaces/") && strings.HasSuffix(path, "/claim-invite"):
+			parts := strings.Split(path, "/")
+			if len(parts) == 4 && parts[3] == "claim-invite" {
+				ctx.SetUserValue("spaceID", parts[2])
+				method := string(ctx.Method())
+				if method == "POST" {
+					authMiddleware.RequireRole(spaceEndpoints.CreateClaimInvite, user.RoleOwner)(ctx)
+				} else {
+					ctx.Error("Method Not Allowed", fasthttp.StatusMethodNotAllowed)
+				}
+			} else {
+				ctx.Error("Not Found", fasthttp.StatusNotFound)
+			}
+		case strings.HasPrefix(path, "/spaces/"):
+			parts := strings.Split(path, "/")
+			if len(parts) == 3 {
+				ctx.SetUserValue("spaceID", parts[2])
+				method := string(ctx.Method())
+				if method == "DELETE" {
+					authMiddleware.RequireRole(spaceEndpoints.DeleteSpace, user.RoleOwner)(ctx)
+				} else {
+					ctx.Error("Method Not Allowed", fasthttp.StatusMethodNotAllowed)
+				}
+			} else {
+				ctx.Error("Not Found", fasthttp.StatusNotFound)
+			}
 
 		default:
 			ctx.Error("Not Found", fasthttp.StatusNotFound)

--- a/internal/invitation/invitation.go
+++ b/internal/invitation/invitation.go
@@ -13,6 +13,7 @@ type Invitation struct {
 	MaxUses            *int    `json:"maxUses,omitempty"`
 	UsedCount          int     `json:"usedCount"`
 	CreatedAt          int64   `json:"createdAt"`
+	SpaceID            *string `json:"spaceId,omitempty"`
 }
 
 // InvitationUse tracks when a user joins via an invitation

--- a/internal/invitation/invitation_endpoints.go
+++ b/internal/invitation/invitation_endpoints.go
@@ -63,6 +63,7 @@ func (ie *InvitationEndpoints) CreateInvite(ctx *fasthttp.RequestCtx) {
 		Role:               req.Role,
 		MaxUses:            req.MaxUses,
 		ExpiresInHours:     req.ExpiresInHours,
+		SpaceID:            spaceIDPtr(authenticatedUser.SpaceID),
 	}
 
 	response, err := ie.invitationService.CreateInvitation(opts)
@@ -280,6 +281,14 @@ func (ie *InvitationEndpoints) RevokeInvite(ctx *fasthttp.RequestCtx) {
 
 	// Return success (204 No Content)
 	ctx.SetStatusCode(fasthttp.StatusNoContent)
+}
+
+// spaceIDPtr converts a space ID string to a pointer, returning nil for empty strings.
+func spaceIDPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }
 
 // ListInvites handles GET /applications/{appID}/invites

--- a/internal/invitation/invitation_repository.go
+++ b/internal/invitation/invitation_repository.go
@@ -28,8 +28,8 @@ func (r *invitationRepository) Create(invite *Invitation) error {
 	query := `
 		INSERT INTO invitations (
 			id, application_id, created_by_public_key,
-			role, max_uses, used_count, created_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7)
+			role, max_uses, used_count, created_at, space_id
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 	`
 
 	_, err := r.db.Exec(query,
@@ -40,6 +40,7 @@ func (r *invitationRepository) Create(invite *Invitation) error {
 		invite.MaxUses,
 		invite.UsedCount,
 		invite.CreatedAt,
+		invite.SpaceID,
 	)
 
 	return err

--- a/internal/invitation/invitation_service.go
+++ b/internal/invitation/invitation_service.go
@@ -55,6 +55,7 @@ type CreateInvitationOptions struct {
 	Role               string
 	MaxUses            *int
 	ExpiresInHours     *int
+	SpaceID            *string
 }
 
 // CreateInvitation creates a new invitation and generates a JWT token
@@ -92,6 +93,7 @@ func (s *InvitationService) CreateInvitation(opts CreateInvitationOptions) (*Inv
 		MaxUses:            opts.MaxUses,
 		UsedCount:          0,
 		CreatedAt:          now,
+		SpaceID:            opts.SpaceID,
 	}
 
 	// Save to database
@@ -460,11 +462,11 @@ func (s *InvitationService) Join(tokenString, userPublicKey, userName string) (*
 			return nil, fmt.Errorf("public key cannot be empty")
 		}
 
-		// Create user with member role
+		// Create user with guest role
 		newUser := &user.User{
 			PublicKey: userPublicKey,
 			Username:  userName,
-			Role:      "member",
+			Role:      user.RoleGuest,
 			CreatedAt: time.Now().Unix(),
 		}
 
@@ -519,6 +521,11 @@ func (s *InvitationService) Join(tokenString, userPublicKey, userName string) (*
 		},
 		CreatedAt:     time.Now().Unix(),
 		ApplicationID: invite.ApplicationID,
+	}
+
+	// Set space ID from invitation so the event is tagged to the correct space
+	if invite.SpaceID != nil {
+		evt.SpaceID = *invite.SpaceID
 	}
 
 	log.Debug().

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -31,15 +31,23 @@ func (am *AuthMiddleware) RequireAuth(handler fasthttp.RequestHandler) fasthttp.
 	}
 }
 
-func (am *AuthMiddleware) RequireRole(role string, handler fasthttp.RequestHandler) fasthttp.RequestHandler {
+func (am *AuthMiddleware) RequireRole(handler fasthttp.RequestHandler, roles ...string) fasthttp.RequestHandler {
 	return am.RequireAuth(func(ctx *fasthttp.RequestCtx) {
 		authenticatedUser, ok := ctx.UserValue("user").(*user.User)
-		if !ok || authenticatedUser.Role != role {
+		if !ok {
 			log.Error().Msg("Insufficient permissions")
 			ctx.Error("Forbidden", fasthttp.StatusForbidden)
 			return
 		}
 
-		handler(ctx)
+		for _, role := range roles {
+			if authenticatedUser.Role == role {
+				handler(ctx)
+				return
+			}
+		}
+
+		log.Error().Str("role", authenticatedUser.Role).Msg("Insufficient permissions")
+		ctx.Error("Forbidden", fasthttp.StatusForbidden)
 	})
 }

--- a/internal/space/space.go
+++ b/internal/space/space.go
@@ -1,0 +1,24 @@
+package space
+
+import "database/sql"
+
+type Space struct {
+	ID            string  `json:"id"`
+	Name          string  `json:"name"`
+	UserPublicKey *string `json:"userPublicKey,omitempty"`
+	CreatedAt     int64   `json:"createdAt"`
+	UpdatedAt     int64   `json:"updatedAt"`
+}
+
+type SpaceRepository interface {
+	Create(space *Space) error
+	GetByID(id string) (*Space, error)
+	GetByUserPublicKey(publicKey string) (*Space, error)
+	List() ([]*Space, error)
+	Delete(id string) error
+	Update(space *Space) error
+}
+
+func NewSpaceRepository(db *sql.DB) SpaceRepository {
+	return &spaceRepository{db: db}
+}

--- a/internal/space/space_endpoints.go
+++ b/internal/space/space_endpoints.go
@@ -1,0 +1,187 @@
+package space
+
+import (
+	"github.com/goccy/go-json"
+	"github.com/prappser/prappser-spaces/internal/user"
+	"github.com/rs/zerolog/log"
+	"github.com/valyala/fasthttp"
+)
+
+// UserRoleUpdater upgrades a user's instance role (e.g., guest -> user on space claim).
+type UserRoleUpdater interface {
+	UpdateUserRole(publicKey string, role string) error
+}
+
+type SpaceEndpoints struct {
+	service         *SpaceService
+	userRoleUpdater UserRoleUpdater
+}
+
+func NewSpaceEndpoints(service *SpaceService, userRoleUpdater UserRoleUpdater) *SpaceEndpoints {
+	return &SpaceEndpoints{service: service, userRoleUpdater: userRoleUpdater}
+}
+
+// CreateSpace handles POST /spaces
+func (se *SpaceEndpoints) CreateSpace(ctx *fasthttp.RequestCtx) {
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(ctx.PostBody(), &body); err != nil {
+		log.Error().Err(err).Msg("[SPACE] Failed to parse request body")
+		ctx.Error("Invalid request body", fasthttp.StatusBadRequest)
+		return
+	}
+
+	if body.Name == "" {
+		ctx.Error("Name is required", fasthttp.StatusBadRequest)
+		return
+	}
+
+	authenticatedUser, ok := ctx.UserValue("user").(*user.User)
+	if !ok || authenticatedUser == nil {
+		log.Error().Msg("[SPACE] Failed to get authenticated user from context")
+		ctx.Error("Unauthorized", fasthttp.StatusUnauthorized)
+		return
+	}
+
+	space, err := se.service.CreateSpace(body.Name, &authenticatedUser.PublicKey)
+	if err != nil {
+		log.Error().Err(err).Msg("[SPACE] Failed to create space")
+		ctx.Error("Failed to create space", fasthttp.StatusInternalServerError)
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusCreated)
+	ctx.SetContentType("application/json")
+	json.NewEncoder(ctx).Encode(space)
+}
+
+// ListSpaces handles GET /spaces
+func (se *SpaceEndpoints) ListSpaces(ctx *fasthttp.RequestCtx) {
+	spaces, err := se.service.ListSpaces()
+	if err != nil {
+		log.Error().Err(err).Msg("[SPACE] Failed to list spaces")
+		ctx.Error("Failed to list spaces", fasthttp.StatusInternalServerError)
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	ctx.SetContentType("application/json")
+	json.NewEncoder(ctx).Encode(spaces)
+}
+
+// DeleteSpace handles DELETE /spaces/:id
+func (se *SpaceEndpoints) DeleteSpace(ctx *fasthttp.RequestCtx) {
+	spaceID, ok := ctx.UserValue("spaceID").(string)
+	if !ok || spaceID == "" {
+		ctx.Error("Space ID is required", fasthttp.StatusBadRequest)
+		return
+	}
+
+	if err := se.service.DeleteSpace(spaceID); err != nil {
+		if err.Error() == "space not found" {
+			ctx.Error("Space not found", fasthttp.StatusNotFound)
+			return
+		}
+		log.Error().Err(err).Msg("[SPACE] Failed to delete space")
+		ctx.Error("Failed to delete space", fasthttp.StatusInternalServerError)
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	ctx.SetContentType("application/json")
+	json.NewEncoder(ctx).Encode(map[string]string{"message": "Space deleted successfully"})
+}
+
+// GetMySpace handles GET /spaces/mine
+func (se *SpaceEndpoints) GetMySpace(ctx *fasthttp.RequestCtx) {
+	authenticatedUser, ok := ctx.UserValue("user").(*user.User)
+	if !ok || authenticatedUser == nil {
+		log.Error().Msg("[SPACE] Failed to get authenticated user from context")
+		ctx.Error("Unauthorized", fasthttp.StatusUnauthorized)
+		return
+	}
+
+	space, err := se.service.GetMySpace(authenticatedUser.PublicKey)
+	if err != nil {
+		log.Error().Err(err).Msg("[SPACE] Failed to get space")
+		ctx.Error("Failed to get space", fasthttp.StatusInternalServerError)
+		return
+	}
+	if space == nil {
+		ctx.Error("Space not found", fasthttp.StatusNotFound)
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	ctx.SetContentType("application/json")
+	json.NewEncoder(ctx).Encode(space)
+}
+
+// CreateClaimInvite handles POST /spaces/:id/claim-invite
+func (se *SpaceEndpoints) CreateClaimInvite(ctx *fasthttp.RequestCtx) {
+	spaceID, ok := ctx.UserValue("spaceID").(string)
+	if !ok || spaceID == "" {
+		ctx.Error("Space ID is required", fasthttp.StatusBadRequest)
+		return
+	}
+
+	response, err := se.service.GenerateClaimInvite(spaceID)
+	if err != nil {
+		if err.Error() == "space not found" {
+			ctx.Error("Space not found", fasthttp.StatusNotFound)
+			return
+		}
+		log.Error().Err(err).Msg("[SPACE] Failed to generate claim invite")
+		ctx.Error("Failed to generate claim invite", fasthttp.StatusInternalServerError)
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusCreated)
+	ctx.SetContentType("application/json")
+	json.NewEncoder(ctx).Encode(response)
+}
+
+// ClaimSpace handles POST /spaces/claim
+func (se *SpaceEndpoints) ClaimSpace(ctx *fasthttp.RequestCtx) {
+	authenticatedUser, ok := ctx.UserValue("user").(*user.User)
+	if !ok || authenticatedUser == nil {
+		log.Error().Msg("[SPACE] Failed to get authenticated user from context")
+		ctx.Error("Unauthorized", fasthttp.StatusUnauthorized)
+		return
+	}
+
+	var body struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(ctx.PostBody(), &body); err != nil || body.Token == "" {
+		ctx.Error("Token is required", fasthttp.StatusBadRequest)
+		return
+	}
+
+	spaceID, err := se.service.ValidateClaimToken(body.Token)
+	if err != nil {
+		log.Error().Err(err).Msg("[SPACE] Invalid claim token")
+		ctx.Error("Invalid or expired claim token", fasthttp.StatusBadRequest)
+		return
+	}
+
+	space, err := se.service.ClaimSpace(spaceID, authenticatedUser.PublicKey)
+	if err != nil {
+		log.Error().Err(err).Msg("[SPACE] Failed to claim space")
+		ctx.Error(err.Error(), fasthttp.StatusConflict)
+		return
+	}
+
+	// Upgrade user role from guest to user on successful claim.
+	if authenticatedUser.Role == user.RoleGuest && se.userRoleUpdater != nil {
+		if err := se.userRoleUpdater.UpdateUserRole(authenticatedUser.PublicKey, user.RoleUser); err != nil {
+			log.Error().Err(err).Msg("[SPACE] Failed to upgrade user role after claim")
+			// Non-fatal: space is claimed, role upgrade can be retried.
+		}
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	ctx.SetContentType("application/json")
+	json.NewEncoder(ctx).Encode(space)
+}

--- a/internal/space/space_repository.go
+++ b/internal/space/space_repository.go
@@ -1,0 +1,120 @@
+package space
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+type spaceRepository struct {
+	db *sql.DB
+}
+
+func (r *spaceRepository) Create(space *Space) error {
+	_, err := r.db.Exec(
+		"INSERT INTO spaces (id, name, user_public_key, created_at, updated_at) VALUES ($1, $2, $3, $4, $5)",
+		space.ID, space.Name, space.UserPublicKey, space.CreatedAt, space.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create space: %w", err)
+	}
+	return nil
+}
+
+func (r *spaceRepository) GetByID(id string) (*Space, error) {
+	var s Space
+	var userPublicKey sql.NullString
+	err := r.db.QueryRow(
+		"SELECT id, name, user_public_key, created_at, updated_at FROM spaces WHERE id = $1",
+		id,
+	).Scan(&s.ID, &s.Name, &userPublicKey, &s.CreatedAt, &s.UpdatedAt)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get space by id: %w", err)
+	}
+	if userPublicKey.Valid {
+		s.UserPublicKey = &userPublicKey.String
+	}
+	return &s, nil
+}
+
+func (r *spaceRepository) GetByUserPublicKey(publicKey string) (*Space, error) {
+	var s Space
+	var userPublicKey sql.NullString
+	err := r.db.QueryRow(
+		"SELECT id, name, user_public_key, created_at, updated_at FROM spaces WHERE user_public_key = $1",
+		publicKey,
+	).Scan(&s.ID, &s.Name, &userPublicKey, &s.CreatedAt, &s.UpdatedAt)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get space by user public key: %w", err)
+	}
+	if userPublicKey.Valid {
+		s.UserPublicKey = &userPublicKey.String
+	}
+	return &s, nil
+}
+
+func (r *spaceRepository) List() ([]*Space, error) {
+	rows, err := r.db.Query(
+		"SELECT id, name, user_public_key, created_at, updated_at FROM spaces ORDER BY created_at DESC",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list spaces: %w", err)
+	}
+	defer rows.Close()
+
+	var spaces []*Space
+	for rows.Next() {
+		s := &Space{}
+		var userPublicKey sql.NullString
+		err := rows.Scan(&s.ID, &s.Name, &userPublicKey, &s.CreatedAt, &s.UpdatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan space: %w", err)
+		}
+		if userPublicKey.Valid {
+			s.UserPublicKey = &userPublicKey.String
+		}
+		spaces = append(spaces, s)
+	}
+
+	return spaces, rows.Err()
+}
+
+func (r *spaceRepository) Delete(id string) error {
+	result, err := r.db.Exec("DELETE FROM spaces WHERE id = $1", id)
+	if err != nil {
+		return fmt.Errorf("failed to delete space: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("space not found")
+	}
+	return nil
+}
+
+func (r *spaceRepository) Update(space *Space) error {
+	result, err := r.db.Exec(
+		"UPDATE spaces SET name = $1, user_public_key = $2, updated_at = $3 WHERE id = $4",
+		space.Name, space.UserPublicKey, space.UpdatedAt, space.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update space: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("space not found")
+	}
+	return nil
+}

--- a/internal/space/space_service.go
+++ b/internal/space/space_service.go
@@ -1,0 +1,143 @@
+package space
+
+import (
+	"crypto/ed25519"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+type SpaceService struct {
+	repo       SpaceRepository
+	privateKey ed25519.PrivateKey
+	publicKey  ed25519.PublicKey
+}
+
+func NewSpaceService(repo SpaceRepository, privateKey ed25519.PrivateKey, publicKey ed25519.PublicKey) *SpaceService {
+	return &SpaceService{repo: repo, privateKey: privateKey, publicKey: publicKey}
+}
+
+func (s *SpaceService) CreateSpace(name string, userPublicKey *string) (*Space, error) {
+	if name == "" {
+		return nil, fmt.Errorf("space name cannot be empty")
+	}
+
+	now := time.Now().Unix()
+	space := &Space{
+		ID:            uuid.New().String(),
+		Name:          name,
+		UserPublicKey: userPublicKey,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+
+	if err := s.repo.Create(space); err != nil {
+		return nil, fmt.Errorf("failed to create space: %w", err)
+	}
+
+	return space, nil
+}
+
+func (s *SpaceService) ListSpaces() ([]*Space, error) {
+	return s.repo.List()
+}
+
+func (s *SpaceService) DeleteSpace(id string) error {
+	return s.repo.Delete(id)
+}
+
+func (s *SpaceService) GetMySpace(userPublicKey string) (*Space, error) {
+	return s.repo.GetByUserPublicKey(userPublicKey)
+}
+
+// ClaimInviteResponse is the response for generating a claim invite token.
+type ClaimInviteResponse struct {
+	Token     string `json:"token"`
+	ExpiresAt int64  `json:"expiresAt"`
+}
+
+// GenerateClaimInvite creates a time-limited JWT token for claiming a space.
+func (s *SpaceService) GenerateClaimInvite(spaceID string) (*ClaimInviteResponse, error) {
+	space, err := s.repo.GetByID(spaceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up space: %w", err)
+	}
+	if space == nil {
+		return nil, fmt.Errorf("space not found")
+	}
+
+	expiresAt := time.Now().Add(48 * time.Hour).Unix()
+
+	claims := jwt.MapClaims{
+		"spaceId": spaceID,
+		"type":    "space_claim",
+		"iat":     time.Now().Unix(),
+		"exp":     expiresAt,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
+	tokenString, err := token.SignedString(s.privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign claim token: %w", err)
+	}
+
+	return &ClaimInviteResponse{
+		Token:     tokenString,
+		ExpiresAt: expiresAt,
+	}, nil
+}
+
+// ValidateClaimToken validates a space claim JWT and returns the space ID.
+func (s *SpaceService) ValidateClaimToken(tokenString string) (string, error) {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodEd25519); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return s.publicKey, nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("invalid claim token: %w", err)
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok || !token.Valid {
+		return "", fmt.Errorf("invalid token claims")
+	}
+
+	claimType, _ := claims["type"].(string)
+	if claimType != "space_claim" {
+		return "", fmt.Errorf("invalid token type")
+	}
+
+	spaceID, ok := claims["spaceId"].(string)
+	if !ok || spaceID == "" {
+		return "", fmt.Errorf("missing spaceId in claim token")
+	}
+
+	return spaceID, nil
+}
+
+// ClaimSpace assigns a space to a user identified by userPublicKey.
+func (s *SpaceService) ClaimSpace(spaceID string, userPublicKey string) (*Space, error) {
+	space, err := s.repo.GetByID(spaceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up space: %w", err)
+	}
+	if space == nil {
+		return nil, fmt.Errorf("space not found")
+	}
+
+	if space.UserPublicKey != nil && *space.UserPublicKey != userPublicKey {
+		return nil, fmt.Errorf("space already claimed by another user")
+	}
+
+	space.UserPublicKey = &userPublicKey
+	space.UpdatedAt = time.Now().Unix()
+	if err := s.repo.Update(space); err != nil {
+		return nil, fmt.Errorf("failed to claim space: %w", err)
+	}
+
+	return space, nil
+}

--- a/internal/storage/endpoints.go
+++ b/internal/storage/endpoints.go
@@ -43,14 +43,16 @@ func (e *Endpoints) Upload(ctx *fasthttp.RequestCtx) {
 
 	var appID *string
 	var publicKey string
+	var spaceID *string
 
 	if appIDStr != "" {
-		aid, pk, ok := e.checkAuthorization(ctx)
+		aid, pk, sid, ok := e.checkAuthorization(ctx)
 		if !ok {
 			return
 		}
 		appID = &aid
 		publicKey = pk
+		spaceID = sid
 	} else {
 		authenticatedUser, ok := ctx.UserValue("user").(*user.User)
 		if !ok || authenticatedUser == nil {
@@ -59,6 +61,9 @@ func (e *Endpoints) Upload(ctx *fasthttp.RequestCtx) {
 			return
 		}
 		publicKey = authenticatedUser.PublicKey
+		if authenticatedUser.SpaceID != "" {
+			spaceID = &authenticatedUser.SpaceID
+		}
 	}
 
 	contentType := string(ctx.Request.Header.ContentType())
@@ -113,7 +118,7 @@ func (e *Endpoints) Upload(ctx *fasthttp.RequestCtx) {
 		req.ContentType = detectContentType(fileHeader.Filename)
 	}
 
-	stored, err := e.service.Upload(ctx, appID, publicKey, req, file)
+	stored, err := e.service.Upload(ctx, appID, publicKey, spaceID, req, file)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to upload file")
 		ctx.Error(err.Error(), fasthttp.StatusBadRequest)
@@ -207,7 +212,12 @@ func (e *Endpoints) UploadUserAvatar(ctx *fasthttp.RequestCtx) {
 		req.ContentType = detectContentType(fileHeader.Filename)
 	}
 
-	stored, err := e.service.Upload(ctx, nil, publicKey, req, file)
+	var avatarSpaceID *string
+	if authenticatedUser.SpaceID != "" {
+		avatarSpaceID = &authenticatedUser.SpaceID
+	}
+
+	stored, err := e.service.Upload(ctx, nil, publicKey, avatarSpaceID, req, file)
 	if err != nil {
 		log.Error().Err(err).Msg("[STORAGE] Failed to upload avatar")
 		ctx.Error("Failed to upload avatar", fasthttp.StatusInternalServerError)
@@ -234,7 +244,7 @@ func (e *Endpoints) UploadUserAvatar(ctx *fasthttp.RequestCtx) {
 }
 
 func (e *Endpoints) InitChunkedUpload(ctx *fasthttp.RequestCtx) {
-	appID, publicKey, ok := e.checkAuthorization(ctx)
+	appID, publicKey, spaceID, ok := e.checkAuthorization(ctx)
 	if !ok {
 		return
 	}
@@ -245,7 +255,7 @@ func (e *Endpoints) InitChunkedUpload(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	response, err := e.service.InitChunkedUpload(ctx, &appID, publicKey, &req)
+	response, err := e.service.InitChunkedUpload(ctx, &appID, publicKey, spaceID, &req)
 	if err != nil {
 		ctx.Error(err.Error(), fasthttp.StatusBadRequest)
 		return
@@ -460,31 +470,34 @@ func (e *Endpoints) DeleteFile(ctx *fasthttp.RequestCtx) {
 	ctx.SetStatusCode(fasthttp.StatusNoContent)
 }
 
-func (e *Endpoints) checkAuthorization(ctx *fasthttp.RequestCtx) (appID, publicKey string, ok bool) {
+func (e *Endpoints) checkAuthorization(ctx *fasthttp.RequestCtx) (appID, publicKey string, spaceID *string, ok bool) {
 	authenticatedUser, ok := ctx.UserValue("user").(*user.User)
 	if !ok || authenticatedUser == nil {
 		ctx.Error("Unauthorized", fasthttp.StatusUnauthorized)
-		return "", "", false
+		return "", "", nil, false
 	}
 	publicKey = authenticatedUser.PublicKey
+	if authenticatedUser.SpaceID != "" {
+		spaceID = &authenticatedUser.SpaceID
+	}
 
 	appID = string(ctx.QueryArgs().Peek("applicationId"))
 	if appID == "" {
 		ctx.Error("applicationId is required", fasthttp.StatusBadRequest)
-		return "", "", false
+		return "", "", nil, false
 	}
 
 	isMember, err := e.appRepo.IsMember(appID, publicKey)
 	if err != nil {
 		ctx.Error("Failed to verify membership", fasthttp.StatusInternalServerError)
-		return "", "", false
+		return "", "", nil, false
 	}
 	if !isMember {
 		ctx.Error("Not a member of this application", fasthttp.StatusForbidden)
-		return "", "", false
+		return "", "", nil, false
 	}
 
-	return appID, publicKey, true
+	return appID, publicKey, spaceID, true
 }
 
 func (e *Endpoints) getStorageAndCheckAccess(ctx *fasthttp.RequestCtx) (stored *Storage, publicKey string, ok bool) {

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -3,6 +3,7 @@ package storage
 type Storage struct {
 	ID                string  `json:"id"`
 	ApplicationID     *string `json:"applicationId,omitempty"`
+	SpaceID           *string `json:"spaceId,omitempty"`
 	UploaderPublicKey string  `json:"uploaderPublicKey"`
 	Filename          string `json:"filename"`
 	ContentType       string `json:"contentType"`

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -14,12 +14,13 @@ func NewRepository(db *sql.DB) *Repository {
 }
 
 func (r *Repository) Create(s *Storage) error {
-	query := `INSERT INTO storage (id, application_id, uploader_public_key, filename, content_type, size_bytes, storage_path, thumbnail_path, width, height, duration_ms, checksum, created_at, status)
-			  VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`
+	query := `INSERT INTO storage (id, application_id, space_id, uploader_public_key, filename, content_type, size_bytes, storage_path, thumbnail_path, width, height, duration_ms, checksum, created_at, status)
+			  VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`
 
 	_, err := r.db.Exec(query,
 		s.ID,
 		s.ApplicationID,
+		s.SpaceID,
 		s.UploaderPublicKey,
 		s.Filename,
 		s.ContentType,

--- a/internal/storage/service.go
+++ b/internal/storage/service.go
@@ -61,7 +61,7 @@ func (s *Service) ExternalURL() string {
 	return s.externalURL
 }
 
-func (s *Service) Upload(ctx context.Context, appID *string, uploaderPublicKey string, req *UploadRequest, data io.Reader) (*Storage, error) {
+func (s *Service) Upload(ctx context.Context, appID *string, uploaderPublicKey string, spaceID *string, req *UploadRequest, data io.Reader) (*Storage, error) {
 	if !allowedContentTypes[req.ContentType] {
 		return nil, fmt.Errorf("unsupported content type: %s", req.ContentType)
 	}
@@ -105,6 +105,7 @@ func (s *Service) Upload(ctx context.Context, appID *string, uploaderPublicKey s
 		Checksum:          checksum,
 		CreatedAt:         now.Unix(),
 		Status:            string(StorageStatusReady),
+		SpaceID:           spaceID,
 	}
 
 	if err := s.repo.Create(stored); err != nil {
@@ -253,7 +254,7 @@ func (s *Service) CleanupApplicationStorage(ctx context.Context, appID string) e
 	return nil
 }
 
-func (s *Service) InitChunkedUpload(ctx context.Context, appID *string, uploaderPublicKey string, req *ChunkedUploadInitRequest) (*ChunkedUploadInitResponse, error) {
+func (s *Service) InitChunkedUpload(ctx context.Context, appID *string, uploaderPublicKey string, spaceID *string, req *ChunkedUploadInitRequest) (*ChunkedUploadInitResponse, error) {
 	if !allowedContentTypes[req.ContentType] {
 		return nil, fmt.Errorf("unsupported content type: %s", req.ContentType)
 	}
@@ -276,6 +277,7 @@ func (s *Service) InitChunkedUpload(ctx context.Context, appID *string, uploader
 		Checksum:          req.Checksum,
 		CreatedAt:         now.Unix(),
 		Status:            string(StorageStatusPending),
+		SpaceID:           spaceID,
 	}
 
 	if err := s.repo.Create(stored); err != nil {

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -20,12 +20,15 @@ const (
 	headerBearer        = "Bearer"
 
 	RoleOwner = "owner"
+	RoleUser  = "user"
+	RoleGuest = "guest"
 )
 
 type User struct {
 	PublicKey       string  `json:"publicKey"`
 	Username        string  `json:"username"`
 	Role            string  `json:"role"`
+	SpaceID         string  `json:"spaceId,omitempty"`
 	CreatedAt       int64   `json:"createdAt"`
 	AvatarStorageID *string `json:"avatarStorageId,omitempty"`
 }
@@ -38,12 +41,18 @@ type UserRepository interface {
 	UpdateAvatarStorageID(publicKey string, avatarStorageID *string) error
 }
 
+// SpaceCreator creates a default space for new owners.
+type SpaceCreator interface {
+	CreateSpace(name string, userPublicKey *string) error
+}
+
 type UserEndpoints struct {
 	userRepository UserRepository
 	config         Config
 	privateKey     ed25519.PrivateKey
 	publicKey      ed25519.PublicKey
 	userService    *UserService
+	spaceCreator   SpaceCreator
 	// Add challenge storage for verification
 	challenges map[string]challengeInfo
 }
@@ -66,6 +75,7 @@ type JWTClaims struct {
 	UserPublicKey string `json:"userPublicKey"`
 	Username      string `json:"username"`
 	Role          string `json:"role"`
+	SpaceID       string `json:"spaceId"`
 	jwt.RegisteredClaims
 }
 
@@ -87,13 +97,14 @@ type challengeInfo struct {
 
 var timeNowFunc = time.Now
 
-func NewEndpoints(userRepository UserRepository, config Config, privateKey ed25519.PrivateKey, publicKey ed25519.PublicKey, userService *UserService) *UserEndpoints {
+func NewEndpoints(userRepository UserRepository, config Config, privateKey ed25519.PrivateKey, publicKey ed25519.PublicKey, userService *UserService, spaceCreator SpaceCreator) *UserEndpoints {
 	return &UserEndpoints{
 		userRepository: userRepository,
 		config:         config,
 		privateKey:     privateKey,
 		publicKey:      publicKey,
 		userService:    userService,
+		spaceCreator:   spaceCreator,
 		challenges:     make(map[string]challengeInfo),
 	}
 }
@@ -151,6 +162,16 @@ func (ue UserEndpoints) OwnerRegister(ctx *fasthttp.RequestCtx) {
 				ctx.Error("Failed to upgrade user to owner", fasthttp.StatusInternalServerError)
 				return
 			}
+
+			// Auto-create default space for newly upgraded owner
+			if ue.spaceCreator != nil {
+				if err := ue.spaceCreator.CreateSpace(existingUser.Username+"'s space", &existingUser.PublicKey); err != nil {
+					log.Error().Err(err).Msg("Failed to create default space for upgraded owner")
+					// Non-fatal: owner is upgraded, space can be created later
+				} else {
+					log.Info().Str("publicKey", existingUser.PublicKey[:min(50, len(existingUser.PublicKey))]+"...").Msg("Default space created for upgraded owner")
+				}
+			}
 		}
 
 		ctx.SetStatusCode(fasthttp.StatusCreated)
@@ -172,6 +193,16 @@ func (ue UserEndpoints) OwnerRegister(ctx *fasthttp.RequestCtx) {
 		log.Error().Err(err).Msg("Failed to create owner")
 		ctx.Error("Failed to create owner", fasthttp.StatusInternalServerError)
 		return
+	}
+
+	// Auto-create default space for new owner
+	if ue.spaceCreator != nil {
+		if err := ue.spaceCreator.CreateSpace(newUser.Username+"'s space", &newUser.PublicKey); err != nil {
+			log.Error().Err(err).Msg("Failed to create default space for new owner")
+			// Non-fatal: owner is created, space can be created later
+		} else {
+			log.Info().Str("publicKey", newUser.PublicKey[:min(50, len(newUser.PublicKey))]+"...").Msg("Default space created for new owner")
+		}
 	}
 
 	ctx.SetStatusCode(fasthttp.StatusCreated)

--- a/internal/user/user_service.go
+++ b/internal/user/user_service.go
@@ -10,16 +10,28 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+// SpaceLookup is a minimal interface to avoid circular dependency with space package.
+type SpaceLookup interface {
+	GetByUserPublicKey(publicKey string) (*SpaceInfo, error)
+}
+
+// SpaceInfo carries the space fields needed for JWT claims.
+type SpaceInfo struct {
+	ID string
+}
+
 type UserService struct {
 	userRepository UserRepository
+	spaceLookup    SpaceLookup
 	config         Config
 	privateKey     ed25519.PrivateKey
 	publicKey      ed25519.PublicKey
 }
 
-func NewUserService(userRepository UserRepository, config Config, privateKey ed25519.PrivateKey, publicKey ed25519.PublicKey) *UserService {
+func NewUserService(userRepository UserRepository, spaceLookup SpaceLookup, config Config, privateKey ed25519.PrivateKey, publicKey ed25519.PublicKey) *UserService {
 	return &UserService{
 		userRepository: userRepository,
+		spaceLookup:    spaceLookup,
 		config:         config,
 		privateKey:     privateKey,
 		publicKey:      publicKey,
@@ -43,10 +55,18 @@ func (us *UserService) ValidateJWTFromRequest(ctx *fasthttp.RequestCtx) (*User, 
 func (us *UserService) GenerateJWT(user *User) (string, int64, error) {
 	expiresAt := time.Now().Add(time.Duration(us.config.JWTExpirationHours) * time.Hour).Unix()
 
+	var spaceID string
+	if us.spaceLookup != nil {
+		if spaceInfo, err := us.spaceLookup.GetByUserPublicKey(user.PublicKey); err == nil && spaceInfo != nil {
+			spaceID = spaceInfo.ID
+		}
+	}
+
 	claims := JWTClaims{
 		UserPublicKey: user.PublicKey,
 		Username:      user.Username,
 		Role:          user.Role,
+		SpaceID:       spaceID,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Unix(expiresAt, 0)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -80,6 +100,7 @@ func (us *UserService) ValidateJWT(tokenString string) (*User, error) {
 		if user == nil {
 			return nil, fmt.Errorf("user not found")
 		}
+		user.SpaceID = claims.SpaceID
 		return user, nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prappser/prappser-spaces/internal/health"
 	"github.com/prappser/prappser-spaces/internal/invitation"
 	"github.com/prappser/prappser-spaces/internal/keys"
+	"github.com/prappser/prappser-spaces/internal/space"
 	"github.com/prappser/prappser-spaces/internal/storage"
 	"github.com/prappser/prappser-spaces/internal/setup"
 	"github.com/prappser/prappser-spaces/internal/status"
@@ -39,6 +40,32 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/valyala/fasthttp"
 )
+
+// spaceLookupAdapter adapts space.SpaceRepository to user.SpaceLookup.
+type spaceLookupAdapter struct {
+	repo space.SpaceRepository
+}
+
+// spaceCreatorAdapter adapts space.SpaceService to user.SpaceCreator.
+type spaceCreatorAdapter struct {
+	service *space.SpaceService
+}
+
+func (a *spaceCreatorAdapter) CreateSpace(name string, userPublicKey *string) error {
+	_, err := a.service.CreateSpace(name, userPublicKey)
+	return err
+}
+
+func (a *spaceLookupAdapter) GetByUserPublicKey(publicKey string) (*user.SpaceInfo, error) {
+	s, err := a.repo.GetByUserPublicKey(publicKey)
+	if err != nil {
+		return nil, err
+	}
+	if s == nil {
+		return nil, nil
+	}
+	return &user.SpaceInfo{ID: s.ID}, nil
+}
 
 func initLogging() {
 	level := os.Getenv("LOG_LEVEL")
@@ -107,8 +134,10 @@ func main() {
 		log.Info().Int("count", count).Msg("[DEBUG] Total registered users")
 	}
 
-	userService := user.NewUserService(userRepository, config.Users, privateKey, publicKey)
-	userEndpoints := user.NewEndpoints(userRepository, config.Users, privateKey, publicKey, userService)
+	spaceRepository := space.NewSpaceRepository(db)
+	spaceService := space.NewSpaceService(spaceRepository, privateKey, publicKey)
+	userService := user.NewUserService(userRepository, &spaceLookupAdapter{repo: spaceRepository}, config.Users, privateKey, publicKey)
+	userEndpoints := user.NewEndpoints(userRepository, config.Users, privateKey, publicKey, userService, &spaceCreatorAdapter{service: spaceService})
 	healthEndpoints := health.NewEndpoints("1.0.0")
 
 	appRepository := application.NewRepository(db)
@@ -164,7 +193,9 @@ func main() {
 
 	wsHandler := websocket.NewHandler(wsHub, userService)
 
-	requestHandler := internal.NewRequestHandler(config, userEndpoints, statusEndpoints, healthEndpoints, userService, appEndpoints, invitationEndpoints, eventEndpoints, setupEndpoints, storageEndpoints, wsHandler)
+	spaceEndpoints := space.NewSpaceEndpoints(spaceService, userRepository)
+
+	requestHandler := internal.NewRequestHandler(config, userEndpoints, statusEndpoints, healthEndpoints, userService, appEndpoints, invitationEndpoints, eventEndpoints, setupEndpoints, storageEndpoints, wsHandler, spaceEndpoints)
 
 	serverAddr := fmt.Sprintf(":%s", config.Port)
 	log.Info().Str("addr", serverAddr).Msg("Starting HTTP server")


### PR DESCRIPTION
## Summary
- Add `spaces` table + migration (000012)
- New `space` package with CRUD, claim invite, and role upgrade
- Add `space_id` FK to applications, events, invitations, storage
- Space-scope all existing endpoints, relax role requirements to allow `RoleUser`
- Auto-create default space on owner registration

## Test plan
- [x] `go build` passes
- [ ] Run migration against dev database
- [ ] Manual: register owner, verify default space created
- [ ] Manual: claim invite flow, verify role upgrade guest -> user