### PR TITLE
feat(push): move VAPID identity from per-user to per-space

### DIFF
--- a/files/migrations/000017_per_space_vapid.down.sql
+++ b/files/migrations/000017_per_space_vapid.down.sql
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS space_vapid;
+
+CREATE TABLE push_vapid_keys (
+    user_public_key TEXT PRIMARY KEY REFERENCES users(public_key) ON DELETE CASCADE,
+    vapid_public_key TEXT NOT NULL,
+    vapid_private_key TEXT NOT NULL,
+    updated_at BIGINT NOT NULL
+);

--- a/files/migrations/000017_per_space_vapid.up.sql
+++ b/files/migrations/000017_per_space_vapid.up.sql
@@ -1,0 +1,10 @@
+-- Intentionally drops push_vapid_keys (per-user VAPID rows) as part of the migration to a single per-space keypair.
+DROP TABLE IF EXISTS push_vapid_keys;
+
+CREATE TABLE space_vapid (
+    id                SMALLINT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    vapid_public_key  TEXT NOT NULL,
+    vapid_private_key TEXT NOT NULL,
+    created_at        BIGINT NOT NULL,
+    updated_at        BIGINT NOT NULL
+);

--- a/internal/http.go
+++ b/internal/http.go
@@ -291,10 +291,10 @@ func NewRequestHandler(config *Config, userEndpoints *user.UserEndpoints, status
 				ctx.Error("Not Found", fasthttp.StatusNotFound)
 			}
 
-		case path == "/push/vapid":
+		case path == "/push/vapid-public-key":
 			method := string(ctx.Method())
-			if method == "PUT" {
-				authMiddleware.RequireAuth(pushEndpoints.SetVapidKeys)(ctx)
+			if method == "GET" {
+				pushEndpoints.GetVapidPublicKey(ctx)
 			} else {
 				ctx.Error("Method Not Allowed", fasthttp.StatusMethodNotAllowed)
 			}

--- a/internal/push/push.go
+++ b/internal/push/push.go
@@ -4,12 +4,13 @@ import (
 	"github.com/prappser/prappser-spaces/internal/event"
 )
 
-// VapidKey holds a user's VAPID keypair for signing web push messages.
-type VapidKey struct {
-	UserPublicKey  string
-	VapidPublicKey string
+// SpaceVapid holds the space-level VAPID keypair for signing web push messages.
+// The singleton row always has id = 1 (enforced by a CHECK constraint in the DB).
+type SpaceVapid struct {
+	VapidPublicKey  string
 	VapidPrivateKey string
-	UpdatedAt      int64
+	CreatedAt       int64
+	UpdatedAt       int64
 }
 
 // Categories controls which buckets of events trigger a push for a subscription.
@@ -61,14 +62,14 @@ type SendResult struct {
 // No context parameter: HTTPWebpushSender builds its own 10-second timeout context internally,
 // so the parameter was unused and misleading.
 type WebpushSender interface {
-	Send(sub *Subscription, vapid *VapidKey, payloadJSON []byte) SendResult
+	Send(sub *Subscription, vapid *SpaceVapid, payloadJSON []byte) SendResult
 }
 
-// PushRepository is the data-access interface for push_vapid_keys and push_subscriptions.
+// PushRepository is the data-access interface for space_vapid and push_subscriptions.
 // The concrete implementation is in push_repository.go.
 type PushRepository interface {
-	UpsertVapidKey(key *VapidKey) error
-	GetVapidKey(userPublicKey string) (*VapidKey, error)
+	UpsertSpaceVapid(v *SpaceVapid) error
+	GetSpaceVapid() (*SpaceVapid, error)
 	CreateSubscription(s *Subscription) error
 	UpdateSubscription(s *Subscription) error
 	DeleteSubscription(id, userPublicKey string) error

--- a/internal/push/push_endpoints.go
+++ b/internal/push/push_endpoints.go
@@ -10,67 +10,25 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-// PushEndpoints exposes HTTP handlers for VAPID key management and subscription CRUD.
+// PushEndpoints exposes HTTP handlers for VAPID public key retrieval and subscription CRUD.
 type PushEndpoints struct {
-	service *PushService
-	repo    PushRepository
+	service      *PushService
+	repo         PushRepository
+	vapidService *SpaceVapidService
 }
 
 // NewPushEndpoints creates a new PushEndpoints.
-func NewPushEndpoints(service *PushService, repo PushRepository) *PushEndpoints {
-	return &PushEndpoints{service: service, repo: repo}
+func NewPushEndpoints(service *PushService, repo PushRepository, vapidService *SpaceVapidService) *PushEndpoints {
+	return &PushEndpoints{service: service, repo: repo, vapidService: vapidService}
 }
 
-// setVapidKeysRequest is the request body for PUT /push/vapid.
-type setVapidKeysRequest struct {
-	PublicKey  string `json:"publicKey"`
-	PrivateKey string `json:"privateKey"`
-}
-
-// SetVapidKeys handles PUT /push/vapid.
-// Upserts the authenticated user's VAPID keypair.
-func (pe *PushEndpoints) SetVapidKeys(ctx *fasthttp.RequestCtx) {
-	authenticatedUser, ok := ctx.UserValue("user").(*user.User)
-	if !ok || authenticatedUser == nil {
-		log.Error().Msg("[PUSH] Failed to get authenticated user from context")
-		ctx.Error("Unauthorized", fasthttp.StatusUnauthorized)
-		return
-	}
-
-	var req setVapidKeysRequest
-	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
-		log.Error().Err(err).Msg("[PUSH] Failed to parse vapid key request body")
-		ctx.SetStatusCode(fasthttp.StatusBadRequest)
-		ctx.SetContentType("application/json")
-		json.NewEncoder(ctx).Encode(map[string]string{"error": "invalid request body"})
-		return
-	}
-
-	if req.PublicKey == "" || req.PrivateKey == "" {
-		log.Error().Msg("[PUSH] Missing publicKey or privateKey in vapid request")
-		ctx.SetStatusCode(fasthttp.StatusBadRequest)
-		ctx.SetContentType("application/json")
-		json.NewEncoder(ctx).Encode(map[string]string{"error": "publicKey and privateKey are required"})
-		return
-	}
-
-	key := &VapidKey{
-		UserPublicKey:   authenticatedUser.PublicKey,
-		VapidPublicKey:  req.PublicKey,
-		VapidPrivateKey: req.PrivateKey,
-		UpdatedAt:       time.Now().Unix(),
-	}
-
-	if err := pe.repo.UpsertVapidKey(key); err != nil {
-		log.Error().Err(err).Msg("[PUSH] Failed to upsert vapid key")
-		ctx.Error("Failed to save VAPID keys", fasthttp.StatusInternalServerError)
-		return
-	}
-
-	log.Debug().Str("userPublicKey", authenticatedUser.PublicKey).Msg("[PUSH] VAPID keys upserted")
+// GetVapidPublicKey handles GET /push/vapid-public-key.
+// Returns the space VAPID public key. No authentication required.
+func (pe *PushEndpoints) GetVapidPublicKey(ctx *fasthttp.RequestCtx) {
+	log.Debug().Msg("[PUSH] GetVapidPublicKey called")
 	ctx.SetStatusCode(fasthttp.StatusOK)
 	ctx.SetContentType("application/json")
-	json.NewEncoder(ctx).Encode(map[string]string{"status": "ok"})
+	json.NewEncoder(ctx).Encode(map[string]string{"publicKey": pe.vapidService.PublicKey()})
 }
 
 // createSubscriptionRequest is the request body for POST /push/subscriptions.

--- a/internal/push/push_endpoints_test.go
+++ b/internal/push/push_endpoints_test.go
@@ -30,68 +30,44 @@ func testUser(publicKey string) *user.User {
 	return &user.User{PublicKey: publicKey, Username: "testuser", Role: "user"}
 }
 
-// stubRepo wraps mockPushRepository and wires it into PushEndpoints.
+// newTestEndpoints wires a mock repo and mock VAPID service into PushEndpoints.
 func newTestEndpoints() (*PushEndpoints, *mockPushRepository) {
 	repo := newMockPushRepository()
-	svc := NewPushService(repo, newMockWebpushSender(SendResult{StatusCode: 201}))
-	ep := NewPushEndpoints(svc, repo)
+	vapidSvc := newMockSpaceVapidService("test-pub-key", "test-priv-key")
+	svc := NewPushService(repo, newMockWebpushSender(SendResult{StatusCode: 201}), vapidSvc)
+	ep := NewPushEndpoints(svc, repo, vapidSvc)
 	return ep, repo
 }
 
-// ---- SetVapidKeys ----
+// ---- GetVapidPublicKey ----
 
-func TestSetVapidKeys_ShouldUpsertKeys(t *testing.T) {
+func TestGetVapidPublicKey_ShouldReturn200WithPublicKey(t *testing.T) {
 	// given
-	ep, repo := newTestEndpoints()
-	ctx := newTestRequestCtx("PUT", `{"publicKey":"pub123","privateKey":"priv123"}`)
-	setAuthUser(ctx, testUser("user-pk-1"))
+	ep, _ := newTestEndpoints()
+	ctx := newTestRequestCtx("GET", "")
 
 	// when
-	ep.SetVapidKeys(ctx)
+	ep.GetVapidPublicKey(ctx)
 
 	// then
 	assert.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode())
-	assert.NotNil(t, repo.vapidKeys["user-pk-1"])
-	assert.Equal(t, "pub123", repo.vapidKeys["user-pk-1"].VapidPublicKey)
+	var resp map[string]string
+	err := json.Unmarshal(ctx.Response.Body(), &resp)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-pub-key", resp["publicKey"])
 }
 
-func TestSetVapidKeys_ShouldReturn400WhenMissingPublicKey(t *testing.T) {
+func TestGetVapidPublicKey_ShouldNotRequireAuth(t *testing.T) {
 	// given
 	ep, _ := newTestEndpoints()
-	ctx := newTestRequestCtx("PUT", `{"privateKey":"priv123"}`)
-	setAuthUser(ctx, testUser("user-pk-1"))
+	ctx := newTestRequestCtx("GET", "")
+	// no user injected — unauthenticated request
 
 	// when
-	ep.SetVapidKeys(ctx)
+	ep.GetVapidPublicKey(ctx)
 
-	// then
-	assert.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode())
-}
-
-func TestSetVapidKeys_ShouldReturn400WhenMissingPrivateKey(t *testing.T) {
-	// given
-	ep, _ := newTestEndpoints()
-	ctx := newTestRequestCtx("PUT", `{"publicKey":"pub123"}`)
-	setAuthUser(ctx, testUser("user-pk-1"))
-
-	// when
-	ep.SetVapidKeys(ctx)
-
-	// then
-	assert.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode())
-}
-
-func TestSetVapidKeys_ShouldReturn401WhenNoUser(t *testing.T) {
-	// given
-	ep, _ := newTestEndpoints()
-	ctx := newTestRequestCtx("PUT", `{"publicKey":"pub","privateKey":"priv"}`)
-	// no user injected
-
-	// when
-	ep.SetVapidKeys(ctx)
-
-	// then
-	assert.Equal(t, fasthttp.StatusUnauthorized, ctx.Response.StatusCode())
+	// then: 200 OK without any auth header
+	assert.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode())
 }
 
 // ---- CreateSubscription ----

--- a/internal/push/push_repository.go
+++ b/internal/push/push_repository.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// pushRepository handles all database operations for push_vapid_keys and push_subscriptions.
+// pushRepository handles all database operations for space_vapid and push_subscriptions.
 // It implements the PushRepository interface defined in push.go.
 type pushRepository struct {
 	db *sql.DB
@@ -18,45 +18,45 @@ func NewPushRepository(db *sql.DB) PushRepository {
 	return &pushRepository{db: db}
 }
 
-// UpsertVapidKey inserts or updates a user's VAPID keypair.
-func (r *pushRepository) UpsertVapidKey(key *VapidKey) error {
+// UpsertSpaceVapid inserts or updates the singleton space VAPID keypair (id = 1).
+func (r *pushRepository) UpsertSpaceVapid(v *SpaceVapid) error {
 	query := `
-		INSERT INTO push_vapid_keys (user_public_key, vapid_public_key, vapid_private_key, updated_at)
-		VALUES ($1, $2, $3, $4)
-		ON CONFLICT (user_public_key) DO UPDATE
+		INSERT INTO space_vapid (id, vapid_public_key, vapid_private_key, created_at, updated_at)
+		VALUES (1, $1, $2, $3, $4)
+		ON CONFLICT (id) DO UPDATE
 		  SET vapid_public_key  = EXCLUDED.vapid_public_key,
 		      vapid_private_key = EXCLUDED.vapid_private_key,
 		      updated_at        = EXCLUDED.updated_at`
 
-	_, err := r.db.Exec(query, key.UserPublicKey, key.VapidPublicKey, key.VapidPrivateKey, key.UpdatedAt)
+	_, err := r.db.Exec(query, v.VapidPublicKey, v.VapidPrivateKey, v.CreatedAt, v.UpdatedAt)
 	if err != nil {
-		return fmt.Errorf("failed to upsert vapid key: %w", err)
+		return fmt.Errorf("failed to upsert space vapid: %w", err)
 	}
 	return nil
 }
 
-// GetVapidKey returns the VAPID keypair for the given user public key.
-// Returns nil, nil when no keypair has been registered.
-func (r *pushRepository) GetVapidKey(userPublicKey string) (*VapidKey, error) {
+// GetSpaceVapid returns the singleton space VAPID keypair.
+// Returns nil, nil when no row has been persisted yet.
+func (r *pushRepository) GetSpaceVapid() (*SpaceVapid, error) {
 	query := `
-		SELECT user_public_key, vapid_public_key, vapid_private_key, updated_at
-		FROM push_vapid_keys
-		WHERE user_public_key = $1`
+		SELECT vapid_public_key, vapid_private_key, created_at, updated_at
+		FROM space_vapid
+		WHERE id = 1`
 
-	key := &VapidKey{}
-	err := r.db.QueryRow(query, userPublicKey).Scan(
-		&key.UserPublicKey,
-		&key.VapidPublicKey,
-		&key.VapidPrivateKey,
-		&key.UpdatedAt,
+	v := &SpaceVapid{}
+	err := r.db.QueryRow(query).Scan(
+		&v.VapidPublicKey,
+		&v.VapidPrivateKey,
+		&v.CreatedAt,
+		&v.UpdatedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to get vapid key: %w", err)
+		return nil, fmt.Errorf("failed to get space vapid: %w", err)
 	}
-	return key, nil
+	return v, nil
 }
 
 // CreateSubscription persists a new push subscription.

--- a/internal/push/push_repository_integration_test.go
+++ b/internal/push/push_repository_integration_test.go
@@ -35,10 +35,11 @@ func getTestDB(t *testing.T) *sql.DB {
 			role       TEXT NOT NULL,
 			created_at BIGINT NOT NULL
 		);
-		CREATE TABLE IF NOT EXISTS push_vapid_keys (
-			user_public_key  TEXT PRIMARY KEY REFERENCES users(public_key) ON DELETE CASCADE,
+		CREATE TABLE IF NOT EXISTS space_vapid (
+			id                SMALLINT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
 			vapid_public_key  TEXT NOT NULL,
 			vapid_private_key TEXT NOT NULL,
+			created_at        BIGINT NOT NULL,
 			updated_at        BIGINT NOT NULL
 		);
 		CREATE TABLE IF NOT EXISTS push_subscriptions (
@@ -64,8 +65,8 @@ func getTestDB(t *testing.T) *sql.DB {
 	if _, err := db.Exec("DELETE FROM push_subscriptions"); err != nil {
 		t.Fatalf("Failed to clean push_subscriptions: %v", err)
 	}
-	if _, err := db.Exec("DELETE FROM push_vapid_keys"); err != nil {
-		t.Fatalf("Failed to clean push_vapid_keys: %v", err)
+	if _, err := db.Exec("DELETE FROM space_vapid"); err != nil {
+		t.Fatalf("Failed to clean space_vapid: %v", err)
 	}
 	if _, err := db.Exec("DELETE FROM users WHERE public_key LIKE 'test-%'"); err != nil {
 		t.Fatalf("Failed to clean users: %v", err)
@@ -82,63 +83,84 @@ func getTestDB(t *testing.T) *sql.DB {
 	return db
 }
 
-func TestPushRepository_UpsertAndGetVapidKey_Integration(t *testing.T) {
+func TestPushRepository_UpsertAndGetSpaceVapid_Integration(t *testing.T) {
 	// given
 	db := getTestDB(t)
 	defer db.Close()
 	repo := NewPushRepository(db)
 
-	key := &VapidKey{
-		UserPublicKey:   "test-user-1",
+	now := time.Now().Unix()
+	v := &SpaceVapid{
 		VapidPublicKey:  "vapid-pub-key",
 		VapidPrivateKey: "vapid-priv-key",
-		UpdatedAt:       time.Now().Unix(),
+		CreatedAt:       now,
+		UpdatedAt:       now,
 	}
 
 	// when: upsert
-	err := repo.UpsertVapidKey(key)
+	err := repo.UpsertSpaceVapid(v)
 
 	// then
 	assert.NoError(t, err)
 
-	got, err := repo.GetVapidKey("test-user-1")
+	got, err := repo.GetSpaceVapid()
 	assert.NoError(t, err)
 	assert.NotNil(t, got)
 	assert.Equal(t, "vapid-pub-key", got.VapidPublicKey)
 	assert.Equal(t, "vapid-priv-key", got.VapidPrivateKey)
+	assert.Equal(t, now, got.CreatedAt)
 }
 
-func TestPushRepository_UpsertVapidKey_ShouldUpdateOnConflict_Integration(t *testing.T) {
+func TestPushRepository_UpsertSpaceVapid_ShouldUpdateOnConflict_Integration(t *testing.T) {
 	// given
 	db := getTestDB(t)
 	defer db.Close()
 	repo := NewPushRepository(db)
 
-	first := &VapidKey{UserPublicKey: "test-user-1", VapidPublicKey: "pub-v1", VapidPrivateKey: "priv-v1", UpdatedAt: time.Now().Unix()}
-	second := &VapidKey{UserPublicKey: "test-user-1", VapidPublicKey: "pub-v2", VapidPrivateKey: "priv-v2", UpdatedAt: time.Now().Unix()}
+	now := time.Now().Unix()
+	first := &SpaceVapid{VapidPublicKey: "pub-v1", VapidPrivateKey: "priv-v1", CreatedAt: now, UpdatedAt: now}
+	second := &SpaceVapid{VapidPublicKey: "pub-v2", VapidPrivateKey: "priv-v2", CreatedAt: now, UpdatedAt: now + 1}
 
 	// when: upsert twice
-	assert.NoError(t, repo.UpsertVapidKey(first))
-	assert.NoError(t, repo.UpsertVapidKey(second))
+	assert.NoError(t, repo.UpsertSpaceVapid(first))
+	assert.NoError(t, repo.UpsertSpaceVapid(second))
 
 	// then: second values win
-	got, err := repo.GetVapidKey("test-user-1")
+	got, err := repo.GetSpaceVapid()
 	assert.NoError(t, err)
 	assert.Equal(t, "pub-v2", got.VapidPublicKey)
+	assert.Equal(t, now+1, got.UpdatedAt)
 }
 
-func TestPushRepository_GetVapidKey_ShouldReturnNilWhenNotFound_Integration(t *testing.T) {
+func TestPushRepository_GetSpaceVapid_ShouldReturnNilWhenNotFound_Integration(t *testing.T) {
 	// given
 	db := getTestDB(t)
 	defer db.Close()
 	repo := NewPushRepository(db)
 
 	// when
-	got, err := repo.GetVapidKey("nonexistent-key")
+	got, err := repo.GetSpaceVapid()
 
 	// then
 	assert.NoError(t, err)
 	assert.Nil(t, got)
+}
+
+func TestPushRepository_UpsertSpaceVapid_ShouldRejectIdNotOne_Integration(t *testing.T) {
+	// given
+	db := getTestDB(t)
+	defer db.Close()
+
+	now := time.Now().Unix()
+
+	// when: attempt to insert with id = 2 directly (bypasses repository to test DB constraint)
+	_, err := db.Exec(
+		`INSERT INTO space_vapid (id, vapid_public_key, vapid_private_key, created_at, updated_at) VALUES ($1, $2, $3, $4, $5)`,
+		2, "pub", "priv", now, now,
+	)
+
+	// then: CHECK (id = 1) violation
+	assert.Error(t, err)
 }
 
 func TestPushRepository_CreateAndGetSubscription_Integration(t *testing.T) {

--- a/internal/push/push_sender.go
+++ b/internal/push/push_sender.go
@@ -21,7 +21,7 @@ func NewHTTPWebpushSender() *HTTPWebpushSender {
 // Send delivers payloadJSON to the given subscription using VAPID authentication.
 // A 10-second per-call context timeout is applied automatically.
 // The response body is drained and closed before returning.
-func (s *HTTPWebpushSender) Send(sub *Subscription, vapid *VapidKey, payloadJSON []byte) SendResult {
+func (s *HTTPWebpushSender) Send(sub *Subscription, vapid *SpaceVapid, payloadJSON []byte) SendResult {
 	sendCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/internal/push/push_service.go
+++ b/internal/push/push_service.go
@@ -11,13 +11,14 @@ import (
 
 // PushService fans out web push notifications to subscribers after an event is accepted.
 type PushService struct {
-	repo   PushRepository
-	sender WebpushSender
+	repo         PushRepository
+	sender       WebpushSender
+	vapidService *SpaceVapidService
 }
 
-// NewPushService creates a PushService with the given repository and sender.
-func NewPushService(repo PushRepository, sender WebpushSender) *PushService {
-	return &PushService{repo: repo, sender: sender}
+// NewPushService creates a PushService with the given repository, sender, and VAPID service.
+func NewPushService(repo PushRepository, sender WebpushSender, vapidService *SpaceVapidService) *PushService {
+	return &PushService{repo: repo, sender: sender, vapidService: vapidService}
 }
 
 // Push delivers a web push notification for ev to each recipient in recipientPublicKeys.
@@ -65,9 +66,10 @@ func (s *PushService) fanout(ev *event.Event, appName string, creatorDisplayName
 		return
 	}
 
-	// Cache VAPID keys per owner to avoid repeated DB round-trips when one user
-	// has multiple subscriptions.
-	vapidCache := make(map[string]*VapidKey)
+	vapid := &SpaceVapid{
+		VapidPublicKey:  s.vapidService.PublicKey(),
+		VapidPrivateKey: s.vapidService.PrivateKey(),
+	}
 
 	// then: deliver to each matching subscription
 	for _, sub := range subs {
@@ -76,32 +78,12 @@ func (s *PushService) fanout(ev *event.Event, appName string, creatorDisplayName
 			continue
 		}
 
-		vapid, cached := vapidCache[sub.UserPublicKey]
-		if !cached {
-			vapid, err = s.repo.GetVapidKey(sub.UserPublicKey)
-			if err != nil {
-				log.Warn().Err(err).
-					Str("userPublicKey", sub.UserPublicKey).
-					Msg("[PUSH] Failed to fetch VAPID key")
-				continue
-			}
-			vapidCache[sub.UserPublicKey] = vapid
-		}
-
-		if vapid == nil {
-			log.Debug().
-				Str("userPublicKey", sub.UserPublicKey).
-				Str("subscriptionId", sub.ID).
-				Msg("[PUSH] No VAPID key for user - skipping subscription")
-			continue
-		}
-
 		s.deliver(sub, vapid, payload)
 	}
 }
 
 // deliver sends one push and updates subscription health fields based on the result.
-func (s *PushService) deliver(sub *Subscription, vapid *VapidKey, payload []byte) {
+func (s *PushService) deliver(sub *Subscription, vapid *SpaceVapid, payload []byte) {
 	result := s.sender.Send(sub, vapid, payload)
 
 	if result.Err != nil {

--- a/internal/push/push_service_test.go
+++ b/internal/push/push_service_test.go
@@ -14,7 +14,7 @@ import (
 type mockPushRepository struct {
 	mu            sync.Mutex
 	subscriptions map[string]*Subscription
-	vapidKeys     map[string]*VapidKey
+	spaceVapid    *SpaceVapid
 	markSuccessCalls []struct {
 		id string
 		ts int64
@@ -29,21 +29,20 @@ type mockPushRepository struct {
 func newMockPushRepository() *mockPushRepository {
 	return &mockPushRepository{
 		subscriptions: make(map[string]*Subscription),
-		vapidKeys:     make(map[string]*VapidKey),
 	}
 }
 
-func (m *mockPushRepository) UpsertVapidKey(key *VapidKey) error {
+func (m *mockPushRepository) UpsertSpaceVapid(v *SpaceVapid) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.vapidKeys[key.UserPublicKey] = key
+	m.spaceVapid = v
 	return nil
 }
 
-func (m *mockPushRepository) GetVapidKey(userPublicKey string) (*VapidKey, error) {
+func (m *mockPushRepository) GetSpaceVapid() (*SpaceVapid, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.vapidKeys[userPublicKey], nil
+	return m.spaceVapid, nil
 }
 
 func (m *mockPushRepository) CreateSubscription(s *Subscription) error {
@@ -118,6 +117,13 @@ func (m *mockPushRepository) IncrementFailure(id string) error {
 	return nil
 }
 
+func newMockSpaceVapidService(pub, priv string) *SpaceVapidService {
+	return &SpaceVapidService{
+		publicKey:  pub,
+		privateKey: priv,
+	}
+}
+
 // mockWebpushSender is a hand-written mock sender for unit tests.
 type mockWebpushSender struct {
 	mu     sync.Mutex
@@ -127,6 +133,7 @@ type mockWebpushSender struct {
 
 type sendCall struct {
 	sub     *Subscription
+	vapid   *SpaceVapid
 	payload []byte
 }
 
@@ -134,10 +141,10 @@ func newMockWebpushSender(result SendResult) *mockWebpushSender {
 	return &mockWebpushSender{result: result}
 }
 
-func (m *mockWebpushSender) Send(sub *Subscription, _ *VapidKey, payloadJSON []byte) SendResult {
+func (m *mockWebpushSender) Send(sub *Subscription, vapid *SpaceVapid, payloadJSON []byte) SendResult {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.calls = append(m.calls, sendCall{sub: sub, payload: payloadJSON})
+	m.calls = append(m.calls, sendCall{sub: sub, vapid: vapid, payload: payloadJSON})
 	return m.result
 }
 
@@ -175,13 +182,9 @@ func TestPushService_Push_ShouldSendForMemberAddedEvent(t *testing.T) {
 	// given
 	repo := newMockPushRepository()
 	sender := newMockWebpushSender(SendResult{StatusCode: 201})
-	svc := NewPushService(repo, sender)
+	vapidSvc := newMockSpaceVapidService("pub", "priv")
+	svc := NewPushService(repo, sender, vapidSvc)
 
-	repo.vapidKeys["user-pk-1"] = &VapidKey{
-		UserPublicKey:   "user-pk-1",
-		VapidPublicKey:  "pub",
-		VapidPrivateKey: "priv",
-	}
 	repo.subscriptions["sub-1"] = &Subscription{
 		ID:                  "sub-1",
 		UserPublicKey:       "user-pk-1",
@@ -207,13 +210,9 @@ func TestPushService_Push_ShouldSkipWhenApplicationMuted(t *testing.T) {
 	// given
 	repo := newMockPushRepository()
 	sender := newMockWebpushSender(SendResult{StatusCode: 201})
-	svc := NewPushService(repo, sender)
+	vapidSvc := newMockSpaceVapidService("pub", "priv")
+	svc := NewPushService(repo, sender, vapidSvc)
 
-	repo.vapidKeys["user-pk-1"] = &VapidKey{
-		UserPublicKey:   "user-pk-1",
-		VapidPublicKey:  "pub",
-		VapidPrivateKey: "priv",
-	}
 	repo.subscriptions["sub-1"] = &Subscription{
 		ID:                  "sub-1",
 		UserPublicKey:       "user-pk-1",
@@ -237,13 +236,9 @@ func TestPushService_Push_ShouldSendWhenDifferentApplicationMuted(t *testing.T) 
 	// given
 	repo := newMockPushRepository()
 	sender := newMockWebpushSender(SendResult{StatusCode: 201})
-	svc := NewPushService(repo, sender)
+	vapidSvc := newMockSpaceVapidService("pub", "priv")
+	svc := NewPushService(repo, sender, vapidSvc)
 
-	repo.vapidKeys["user-pk-1"] = &VapidKey{
-		UserPublicKey:   "user-pk-1",
-		VapidPublicKey:  "pub",
-		VapidPrivateKey: "priv",
-	}
 	repo.subscriptions["sub-1"] = &Subscription{
 		ID:                  "sub-1",
 		UserPublicKey:       "user-pk-1",
@@ -267,13 +262,9 @@ func TestPushService_Push_ShouldDeleteSubscriptionOn410(t *testing.T) {
 	// given
 	repo := newMockPushRepository()
 	sender := newMockWebpushSender(SendResult{StatusCode: 410})
-	svc := NewPushService(repo, sender)
+	vapidSvc := newMockSpaceVapidService("pub", "priv")
+	svc := NewPushService(repo, sender, vapidSvc)
 
-	repo.vapidKeys["user-pk-1"] = &VapidKey{
-		UserPublicKey:   "user-pk-1",
-		VapidPublicKey:  "pub",
-		VapidPrivateKey: "priv",
-	}
 	repo.subscriptions["sub-1"] = &Subscription{
 		ID:                  "sub-1",
 		UserPublicKey:       "user-pk-1",
@@ -301,13 +292,9 @@ func TestPushService_Push_ShouldIncrementFailureOn429(t *testing.T) {
 	// given
 	repo := newMockPushRepository()
 	sender := newMockWebpushSender(SendResult{StatusCode: 429})
-	svc := NewPushService(repo, sender)
+	vapidSvc := newMockSpaceVapidService("pub", "priv")
+	svc := NewPushService(repo, sender, vapidSvc)
 
-	repo.vapidKeys["user-pk-1"] = &VapidKey{
-		UserPublicKey:   "user-pk-1",
-		VapidPublicKey:  "pub",
-		VapidPrivateKey: "priv",
-	}
 	repo.subscriptions["sub-1"] = &Subscription{
 		ID:                  "sub-1",
 		UserPublicKey:       "user-pk-1",
@@ -337,13 +324,9 @@ func TestPushService_Push_ShouldSkipWhenEventTypeHasNoCategory(t *testing.T) {
 	// given
 	repo := newMockPushRepository()
 	sender := newMockWebpushSender(SendResult{StatusCode: 201})
-	svc := NewPushService(repo, sender)
+	vapidSvc := newMockSpaceVapidService("pub", "priv")
+	svc := NewPushService(repo, sender, vapidSvc)
 
-	repo.vapidKeys["user-pk-1"] = &VapidKey{
-		UserPublicKey:   "user-pk-1",
-		VapidPublicKey:  "pub",
-		VapidPrivateKey: "priv",
-	}
 	repo.subscriptions["sub-1"] = &Subscription{
 		ID:                  "sub-1",
 		UserPublicKey:       "user-pk-1",
@@ -364,28 +347,43 @@ func TestPushService_Push_ShouldSkipWhenEventTypeHasNoCategory(t *testing.T) {
 	assert.Equal(t, 0, sender.callCount())
 }
 
-func TestPushService_Push_ShouldSkipWhenNoVapidKey(t *testing.T) {
+func TestPushService_Push_ShouldUseSpaceVapidForAllRecipients(t *testing.T) {
 	// given
 	repo := newMockPushRepository()
 	sender := newMockWebpushSender(SendResult{StatusCode: 201})
-	svc := NewPushService(repo, sender)
+	vapidSvc := newMockSpaceVapidService("space-pub-key", "space-priv-key")
+	svc := NewPushService(repo, sender, vapidSvc)
 
-	// No VAPID key registered for this user
 	repo.subscriptions["sub-1"] = &Subscription{
 		ID:                  "sub-1",
 		UserPublicKey:       "user-pk-1",
 		Endpoint:            "https://push.example.com/1",
-		P256dh:              "p256dh-value",
-		Auth:                "auth-value",
+		P256dh:              "p256dh-1",
+		Auth:                "auth-1",
+		MutedApplicationIDs: []string{},
+	}
+	repo.subscriptions["sub-2"] = &Subscription{
+		ID:                  "sub-2",
+		UserPublicKey:       "user-pk-2",
+		Endpoint:            "https://push.example.com/2",
+		P256dh:              "p256dh-2",
+		Auth:                "auth-2",
 		MutedApplicationIDs: []string{},
 	}
 
 	ev := makeEvent(event.EventTypeMemberAdded, "creator-pk", "app-1")
 
 	// when
-	svc.Push(ev, "", "", []string{"user-pk-1"})
+	svc.Push(ev, "", "", []string{"user-pk-1", "user-pk-2"})
 
-	// then: sender not called because there is no VAPID key
-	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, 0, sender.callCount())
+	// then: both deliveries used the same space VAPID keys
+	assert.True(t, sender.waitForCalls(2, 2*time.Second), "expected 2 Send calls")
+	sender.mu.Lock()
+	calls := sender.calls
+	sender.mu.Unlock()
+	assert.Len(t, calls, 2)
+	for _, c := range calls {
+		assert.Equal(t, "space-pub-key", c.vapid.VapidPublicKey)
+		assert.Equal(t, "space-priv-key", c.vapid.VapidPrivateKey)
+	}
 }

--- a/internal/push/space_vapid_service.go
+++ b/internal/push/space_vapid_service.go
@@ -1,0 +1,84 @@
+package push
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	webpush "github.com/SherClockHolmes/webpush-go"
+	"github.com/rs/zerolog/log"
+)
+
+// SpaceVapidService manages the singleton VAPID keypair for the space.
+// Keys are loaded (or generated) once at startup via Initialize and then
+// served from memory for every push delivery.
+type SpaceVapidService struct {
+	repo       PushRepository
+	publicKey  string
+	privateKey string
+}
+
+// NewSpaceVapidService creates a SpaceVapidService backed by the given repository.
+func NewSpaceVapidService(repo PushRepository) *SpaceVapidService {
+	return &SpaceVapidService{repo: repo}
+}
+
+// Initialize loads the existing space VAPID keypair from the database.
+// If no row exists, a new keypair is generated and persisted.
+// Must be called once at startup before any push deliveries.
+func (s *SpaceVapidService) Initialize(ctx context.Context) error {
+	existing, err := s.repo.GetSpaceVapid()
+	if err != nil {
+		return fmt.Errorf("failed to load space vapid: %w", err)
+	}
+
+	if existing != nil {
+		s.publicKey = existing.VapidPublicKey
+		s.privateKey = existing.VapidPrivateKey
+		log.Info().Msg("Space VAPID keys loaded from database")
+		return nil
+	}
+
+	log.Info().Msg("No space VAPID keys found, generating new keypair...")
+
+	privKey, pubKey, err := webpush.GenerateVAPIDKeys()
+	if err != nil {
+		return fmt.Errorf("failed to generate VAPID keys: %w", err)
+	}
+
+	now := time.Now().Unix()
+	v := &SpaceVapid{
+		VapidPublicKey:  pubKey,
+		VapidPrivateKey: privKey,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+
+	if err := s.repo.UpsertSpaceVapid(v); err != nil {
+		return fmt.Errorf("failed to persist space vapid: %w", err)
+	}
+
+	// Re-read after upsert so concurrent startups converge on the winner in DB.
+	persisted, err := s.repo.GetSpaceVapid()
+	if err != nil {
+		return fmt.Errorf("failed to reload space vapid after upsert: %w", err)
+	}
+	if persisted == nil {
+		return fmt.Errorf("space vapid row missing after upsert")
+	}
+
+	s.publicKey = persisted.VapidPublicKey
+	s.privateKey = persisted.VapidPrivateKey
+	log.Info().Msg("New space VAPID keypair generated and stored")
+	return nil
+}
+
+// PublicKey returns the cached VAPID public key.
+func (s *SpaceVapidService) PublicKey() string {
+	return s.publicKey
+}
+
+// PrivateKey returns the cached VAPID private key.
+func (s *SpaceVapidService) PrivateKey() string {
+	return s.privateKey
+}

--- a/internal/push/space_vapid_service_test.go
+++ b/internal/push/space_vapid_service_test.go
@@ -1,0 +1,70 @@
+package push
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpaceVapidService_Initialize_ShouldGenerateOnFirstCall(t *testing.T) {
+	// given
+	repo := newMockPushRepository()
+	svc := NewSpaceVapidService(repo)
+
+	// when
+	err := svc.Initialize(context.Background())
+
+	// then: keys generated and cached
+	assert.NoError(t, err)
+	assert.NotEmpty(t, svc.PublicKey())
+	assert.NotEmpty(t, svc.PrivateKey())
+
+	// and: persisted to repo
+	repo.mu.Lock()
+	stored := repo.spaceVapid
+	repo.mu.Unlock()
+	assert.NotNil(t, stored)
+	assert.Equal(t, svc.PublicKey(), stored.VapidPublicKey)
+	assert.Equal(t, svc.PrivateKey(), stored.VapidPrivateKey)
+}
+
+func TestSpaceVapidService_Initialize_ShouldBeIdempotentOnSecondCall(t *testing.T) {
+	// given
+	repo := newMockPushRepository()
+	svc := NewSpaceVapidService(repo)
+	assert.NoError(t, svc.Initialize(context.Background()))
+	firstPub := svc.PublicKey()
+	firstPriv := svc.PrivateKey()
+
+	// when: initialize again with same repo (already has a row)
+	svc2 := NewSpaceVapidService(repo)
+	err := svc2.Initialize(context.Background())
+
+	// then: same keys loaded, no new generation
+	assert.NoError(t, err)
+	assert.Equal(t, firstPub, svc2.PublicKey())
+	assert.Equal(t, firstPriv, svc2.PrivateKey())
+}
+
+func TestSpaceVapidService_Initialize_ShouldLoadExisting(t *testing.T) {
+	// given
+	repo := newMockPushRepository()
+	now := time.Now().Unix()
+	repo.spaceVapid = &SpaceVapid{
+		VapidPublicKey:  "seeded-pub",
+		VapidPrivateKey: "seeded-priv",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	svc := NewSpaceVapidService(repo)
+
+	// when
+	err := svc.Initialize(context.Background())
+
+	// then: cached keys match seeded values
+	assert.NoError(t, err)
+	assert.Equal(t, "seeded-pub", svc.PublicKey())
+	assert.Equal(t, "seeded-priv", svc.PrivateKey())
+}

--- a/main.go
+++ b/main.go
@@ -153,9 +153,13 @@ func main() {
 	eventRepository := event.NewEventRepository(db)
 
 	pushRepo := push.NewPushRepository(db)
+	pushVapidService := push.NewSpaceVapidService(pushRepo)
+	if err := pushVapidService.Initialize(context.Background()); err != nil {
+		log.Fatal().Err(err).Msg("Failed to initialize space VAPID keys")
+	}
 	pushSender := push.NewHTTPWebpushSender()
-	pushService := push.NewPushService(pushRepo, pushSender)
-	pushEndpoints := push.NewPushEndpoints(pushService, pushRepo)
+	pushService := push.NewPushService(pushRepo, pushSender, pushVapidService)
+	pushEndpoints := push.NewPushEndpoints(pushService, pushRepo, pushVapidService)
 
 	eventService := event.NewEventService(eventRepository, appRepository, wsHub, pushService)
 	eventEndpoints := event.NewEventEndpoints(eventService)


### PR DESCRIPTION
The server now owns a single VAPID keypair, generated once on startup and persisted in a new space_vapid singleton table. The old per-user push_vapid_keys table is dropped (clients used to generate their VAPID locally and upload the private key to every space they joined, a leak of client-side secrets).

New unauthenticated GET /push/vapid-public-key exposes the public key so clients can pin it to their pushManager.subscribe call. The old PUT /push/vapid upload endpoint is gone. SpaceVapidService.Initialize re-reads after upsert so concurrent startups converge on the DB winner.