### PR TITLE
fix(storage): 404 missing blobs, drop pending rows, sweep stale pendi…

### DIFF
--- a/internal/storage/endpoints.go
+++ b/internal/storage/endpoints.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -23,15 +24,35 @@ type EventService interface {
 	ProduceEvent(ctx context.Context, e *event.Event) (*event.Event, error)
 }
 
+// storageService is the narrow interface Endpoints needs from *Service.
+// The concrete *Service satisfies it; tests inject a mock.
+type storageService interface {
+	Upload(ctx context.Context, appID *string, uploaderPublicKey string, spaceID *string, req *UploadRequest, data io.Reader, baseURL string) (*Storage, error)
+	Get(ctx context.Context, id string, baseURL string) (*Storage, error)
+	GetData(ctx context.Context, id string) (io.ReadCloser, *Storage, error)
+	GetThumbnail(ctx context.Context, id string) (io.ReadCloser, *Storage, error)
+	Delete(ctx context.Context, id, requestorPublicKey string) error
+	InitChunkedUpload(ctx context.Context, appID *string, uploaderPublicKey string, spaceID *string, req *ChunkedUploadInitRequest) (*ChunkedUploadInitResponse, error)
+	UploadChunk(ctx context.Context, storageID string, chunkIndex int, data io.Reader) error
+	CompleteChunkedUpload(ctx context.Context, storageID string, baseURL string) (*Storage, error)
+	CleanupApplicationStorage(ctx context.Context, appID string) error
+}
+
+// appMemberChecker is the narrow interface Endpoints needs from *application.Repository.
+type appMemberChecker interface {
+	IsMember(appID, publicKey string) (bool, error)
+	GetApplicationsByMemberPublicKey(publicKey string) ([]*application.Application, error)
+}
+
 type Endpoints struct {
-	service             *Service
-	appRepo             *application.Repository
+	service             storageService
+	appRepo             appMemberChecker
 	eventService        EventService
 	userRepo            user.UserRepository
 	externalURLOverride string
 }
 
-func NewEndpoints(service *Service, appRepo *application.Repository, eventService EventService, userRepo user.UserRepository, externalURLOverride string) *Endpoints {
+func NewEndpoints(service storageService, appRepo appMemberChecker, eventService EventService, userRepo user.UserRepository, externalURLOverride string) *Endpoints {
 	return &Endpoints{
 		service:             service,
 		appRepo:             appRepo,
@@ -415,6 +436,10 @@ func (e *Endpoints) GetFile(ctx *fasthttp.RequestCtx) {
 	reader, stored, err := e.service.GetData(ctx, storageID)
 	if err != nil {
 		log.Error().Err(err).Str("storageId", storageID).Msg("[STORAGE] GetData failed")
+		if errors.Is(err, ErrBlobNotFound) {
+			ctx.Error("file not found", fasthttp.StatusNotFound)
+			return
+		}
 		ctx.Error("Failed to retrieve file", fasthttp.StatusInternalServerError)
 		return
 	}
@@ -551,6 +576,11 @@ func (e *Endpoints) getStorageAndCheckAccess(ctx *fasthttp.RequestCtx) (stored *
 
 	stored, err := e.service.Get(ctx, storageID, "")
 	if err != nil {
+		ctx.Error("Storage not found", fasthttp.StatusNotFound)
+		return nil, "", false
+	}
+
+	if stored.Status != string(StorageStatusReady) {
 		ctx.Error("Storage not found", fasthttp.StatusNotFound)
 		return nil, "", false
 	}

--- a/internal/storage/local_storage.go
+++ b/internal/storage/local_storage.go
@@ -56,7 +56,7 @@ func (s *LocalStorage) Get(ctx context.Context, path string) (io.ReadCloser, err
 	file, err := os.Open(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("file not found: %s", path)
+			return nil, fmt.Errorf("%w: %s", ErrBlobNotFound, path)
 		}
 		return nil, err
 	}

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -217,6 +217,60 @@ func (r *Repository) DeleteChunks(storageID string) error {
 	return err
 }
 
+// DeleteStalePending deletes storage rows with status='pending' older than
+// olderThanSeconds seconds (Unix timestamp cutoff). It first deletes orphaned
+// storage_chunks rows because storage_chunks has no FK cascade back to storage.
+// Returns the number of storage rows deleted.
+//
+// SQL executed (both inside a single transaction):
+//
+//	DELETE FROM storage_chunks
+//	WHERE storage_id IN (
+//	    SELECT id FROM storage
+//	    WHERE status = 'pending' AND created_at < $1
+//	)
+//
+//	DELETE FROM storage
+//	WHERE status = 'pending' AND created_at < $1
+//
+// NOTE: the unit test (TestCleanupPending_MockWiring) covers service wiring only,
+// not these SQL statements. Add an integration test if the SQL is ever changed.
+func (r *Repository) DeleteStalePending(olderThanSeconds int64) (int, error) {
+	tx, err := r.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Delete chunks for stale pending rows first (no FK cascade on storage_chunks).
+	_, err = tx.Exec(`
+		DELETE FROM storage_chunks
+		WHERE storage_id IN (
+			SELECT id FROM storage
+			WHERE status = 'pending' AND created_at < $1
+		)`, olderThanSeconds)
+	if err != nil {
+		return 0, err
+	}
+
+	result, err := tx.Exec(`
+		DELETE FROM storage
+		WHERE status = 'pending' AND created_at < $1`, olderThanSeconds)
+	if err != nil {
+		return 0, err
+	}
+
+	n, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return int(n), nil
+}
+
 func (r *Repository) GetTotalUsedBytes() (int64, error) {
 	var total sql.NullInt64
 	err := r.db.QueryRow(`SELECT COALESCE(SUM(size_bytes), 0) FROM storage`).Scan(&total)

--- a/internal/storage/s3_storage.go
+++ b/internal/storage/s3_storage.go
@@ -60,7 +60,7 @@ func (s *S3Storage) Get(ctx context.Context, path string) (io.ReadCloser, error)
 	if err != nil {
 		errResponse := minio.ToErrorResponse(err)
 		if errResponse.Code == "NoSuchKey" {
-			return nil, fmt.Errorf("file not found: %s", path)
+			return nil, fmt.Errorf("%w: %s", ErrBlobNotFound, path)
 		}
 		return nil, err
 	}

--- a/internal/storage/service.go
+++ b/internal/storage/service.go
@@ -403,6 +403,64 @@ func (s *Service) CompleteChunkedUpload(ctx context.Context, storageID string, b
 	return stored, nil
 }
 
+// CleanupStalePendingUploads deletes storage rows with status='pending' that
+// were created more than 1 hour ago, along with their orphaned chunk rows.
+func (s *Service) CleanupStalePendingUploads(ctx context.Context) error {
+	cutoff := time.Now().Add(-1 * time.Hour).Unix()
+	n, err := s.repo.DeleteStalePending(cutoff)
+	if err != nil {
+		return err
+	}
+	log.Info().Int("deletedCount", n).Msg("[STORAGE] Stale pending upload cleanup completed")
+	return nil
+}
+
+// PendingCleanupScheduler runs CleanupStalePendingUploads on a fixed interval.
+type PendingCleanupScheduler struct {
+	service  *Service
+	interval time.Duration
+	ticker   *time.Ticker
+	done     chan bool
+}
+
+// NewPendingCleanupScheduler creates a scheduler that will run cleanup every interval.
+func NewPendingCleanupScheduler(service *Service, interval time.Duration) *PendingCleanupScheduler {
+	return &PendingCleanupScheduler{
+		service:  service,
+		interval: interval,
+		done:     make(chan bool),
+	}
+}
+
+// Start begins the cleanup loop in a background goroutine.
+func (p *PendingCleanupScheduler) Start() {
+	p.ticker = time.NewTicker(p.interval)
+	log.Info().Dur("interval", p.interval).Msg("[STORAGE] Pending upload cleanup scheduler started")
+	go p.loop()
+}
+
+func (p *PendingCleanupScheduler) loop() {
+	for {
+		select {
+		case <-p.ticker.C:
+			if err := p.service.CleanupStalePendingUploads(context.Background()); err != nil {
+				log.Error().Err(err).Msg("[STORAGE] Stale pending upload cleanup failed")
+			}
+		case <-p.done:
+			p.ticker.Stop()
+			return
+		}
+	}
+}
+
+// Stop halts the cleanup scheduler.
+func (p *PendingCleanupScheduler) Stop() {
+	log.Info().Msg("[STORAGE] Stopping pending upload cleanup scheduler")
+	if p.ticker != nil {
+		p.done <- true
+	}
+}
+
 func buildStoragePath(appID *string, storageID, filename, contentType string, now time.Time) string {
 	year := now.Format("2006")
 	month := now.Format("01")

--- a/internal/storage/service_test.go
+++ b/internal/storage/service_test.go
@@ -1,0 +1,352 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prappser/prappser-spaces/internal/application"
+	"github.com/prappser/prappser-spaces/internal/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+// ---- mock storage backend ----
+
+type mockBackend struct {
+	mu      sync.Mutex
+	objects map[string]string
+	// getErr, when non-nil, is returned by Get for every path
+	getErr error
+}
+
+func newMockBackend() *mockBackend {
+	return &mockBackend{objects: make(map[string]string)}
+}
+
+func (m *mockBackend) Store(_ context.Context, path string, r io.Reader) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	b, _ := io.ReadAll(r)
+	m.objects[path] = string(b)
+	return nil
+}
+
+func (m *mockBackend) Get(_ context.Context, path string) (io.ReadCloser, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	content, ok := m.objects[path]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrBlobNotFound, path)
+	}
+	return io.NopCloser(strings.NewReader(content)), nil
+}
+
+func (m *mockBackend) Delete(_ context.Context, _ string) error   { return nil }
+func (m *mockBackend) Exists(_ context.Context, _ string) (bool, error) { return false, nil }
+func (m *mockBackend) GetURL(_ context.Context, path, base string) (string, error) {
+	return base + "/storage/" + path, nil
+}
+
+// ---- mock storage repository ----
+
+type mockStorageRepo struct {
+	mu      sync.Mutex
+	records map[string]*Storage
+	chunks  map[string][]*StorageChunk
+}
+
+func newMockStorageRepo() *mockStorageRepo {
+	return &mockStorageRepo{
+		records: make(map[string]*Storage),
+		chunks:  make(map[string][]*StorageChunk),
+	}
+}
+
+func (r *mockStorageRepo) Create(s *Storage) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records[s.ID] = s
+	return nil
+}
+
+func (r *mockStorageRepo) GetByID(id string) (*Storage, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s, ok := r.records[id]
+	if !ok {
+		return nil, fmt.Errorf("storage not found")
+	}
+	return s, nil
+}
+
+func (r *mockStorageRepo) GetByApplicationID(_ string) ([]*Storage, error) { return nil, nil }
+
+func (r *mockStorageRepo) UpdateStatus(id, status string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if s, ok := r.records[id]; ok {
+		s.Status = status
+	}
+	return nil
+}
+
+func (r *mockStorageRepo) UpdateThumbnail(_, _ string) error       { return nil }
+func (r *mockStorageRepo) UpdateDimensions(_ string, _, _ int) error { return nil }
+
+func (r *mockStorageRepo) Delete(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.records, id)
+	return nil
+}
+
+func (r *mockStorageRepo) CreateChunk(chunk *StorageChunk) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.chunks[chunk.StorageID] = append(r.chunks[chunk.StorageID], chunk)
+	return nil
+}
+
+func (r *mockStorageRepo) GetChunks(storageID string) ([]*StorageChunk, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.chunks[storageID], nil
+}
+
+func (r *mockStorageRepo) DeleteChunks(storageID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.chunks, storageID)
+	return nil
+}
+
+func (r *mockStorageRepo) GetTotalUsedBytes() (int64, error) { return 0, nil }
+
+// DeleteStalePending implements the same logic as Repository.DeleteStalePending
+// but operates on the in-memory maps.
+func (r *mockStorageRepo) DeleteStalePending(olderThanSeconds int64) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	for id, s := range r.records {
+		if s.Status == string(StorageStatusPending) && s.CreatedAt < olderThanSeconds {
+			delete(r.chunks, id)
+			delete(r.records, id)
+			count++
+		}
+	}
+	return count, nil
+}
+
+// ---- mock app repo ----
+
+type mockAppRepo struct {
+	isMember bool
+}
+
+func (m *mockAppRepo) IsMember(_, _ string) (bool, error) { return m.isMember, nil }
+func (m *mockAppRepo) GetApplicationsByMemberPublicKey(_ string) ([]*application.Application, error) {
+	return nil, nil
+}
+
+// ---- mock service ----
+
+// mockStorageService is a minimal storageService implementation backed by
+// a mockStorageRepo and mockBackend. It only implements the methods exercised
+// by the endpoint tests below.
+type mockStorageService struct {
+	repo    *mockStorageRepo
+	backend *mockBackend
+}
+
+func (m *mockStorageService) Get(_ context.Context, id, _ string) (*Storage, error) {
+	return m.repo.GetByID(id)
+}
+
+func (m *mockStorageService) GetData(_ context.Context, id string) (io.ReadCloser, *Storage, error) {
+	s, err := m.repo.GetByID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	reader, err := m.backend.Get(context.Background(), s.StoragePath)
+	if err != nil {
+		return nil, nil, err
+	}
+	return reader, s, nil
+}
+
+func (m *mockStorageService) GetThumbnail(_ context.Context, id string) (io.ReadCloser, *Storage, error) {
+	return nil, nil, fmt.Errorf("no thumbnail available")
+}
+
+func (m *mockStorageService) Upload(_ context.Context, _ *string, _ string, _ *string, _ *UploadRequest, _ io.Reader, _ string) (*Storage, error) {
+	return nil, fmt.Errorf("not implemented in mock")
+}
+
+func (m *mockStorageService) Delete(_ context.Context, _, _ string) error {
+	return fmt.Errorf("not implemented in mock")
+}
+
+func (m *mockStorageService) InitChunkedUpload(_ context.Context, _ *string, _ string, _ *string, _ *ChunkedUploadInitRequest) (*ChunkedUploadInitResponse, error) {
+	return nil, fmt.Errorf("not implemented in mock")
+}
+
+func (m *mockStorageService) UploadChunk(_ context.Context, _ string, _ int, _ io.Reader) error {
+	return fmt.Errorf("not implemented in mock")
+}
+
+func (m *mockStorageService) CompleteChunkedUpload(_ context.Context, _ string, _ string) (*Storage, error) {
+	return nil, fmt.Errorf("not implemented in mock")
+}
+
+func (m *mockStorageService) CleanupApplicationStorage(_ context.Context, _ string) error {
+	return nil
+}
+
+// ---- helpers ----
+
+func newTestEndpointsStorage(svc storageService, isMember bool) *Endpoints {
+	return &Endpoints{
+		service:  svc,
+		appRepo:  &mockAppRepo{isMember: isMember},
+		userRepo: nil,
+	}
+}
+
+func newTestRequestCtxStorage(method string) *fasthttp.RequestCtx {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(method)
+	return ctx
+}
+
+func setStorageAuthUser(ctx *fasthttp.RequestCtx, u *user.User) {
+	ctx.SetUserValue("user", u)
+}
+
+func storageTestUser(publicKey string) *user.User {
+	return &user.User{PublicKey: publicKey, Username: "testuser", Role: "user"}
+}
+
+// ---- cleanupStalePendingUploads helper (mirrors service logic, uses mock repo) ----
+
+func runCleanupWithMockRepo(repo *mockStorageRepo) error {
+	cutoff := time.Now().Add(-1 * time.Hour).Unix()
+	_, err := repo.DeleteStalePending(cutoff)
+	return err
+}
+
+// ---- tests ----
+
+// TestGetFile_BlobMissing_Returns404 verifies that when the storage record
+// exists with status=ready but the backend blob is missing, GetFile returns 404.
+func TestGetFile_BlobMissing_Returns404(t *testing.T) {
+	// given
+	backend := newMockBackend()
+	backend.getErr = fmt.Errorf("%w: some/path.jpg", ErrBlobNotFound)
+
+	repo := newMockStorageRepo()
+	repo.records["file-1"] = &Storage{
+		ID:                "file-1",
+		UploaderPublicKey: "user-pk-1",
+		Filename:          "photo.jpg",
+		ContentType:       "image/jpeg",
+		SizeBytes:         1024,
+		StoragePath:       "app-1/2026/05/file-1.jpg",
+		CreatedAt:         time.Now().Unix(),
+		Status:            string(StorageStatusReady),
+	}
+
+	svc := &mockStorageService{repo: repo, backend: backend}
+	ep := newTestEndpointsStorage(svc, true)
+
+	ctx := newTestRequestCtxStorage("GET")
+	setStorageAuthUser(ctx, storageTestUser("user-pk-1"))
+	ctx.SetUserValue("storageID", "file-1")
+
+	// when
+	ep.GetFile(ctx)
+
+	// then
+	assert.Equal(t, fasthttp.StatusNotFound, ctx.Response.StatusCode())
+	assert.Contains(t, string(ctx.Response.Body()), "file not found")
+}
+
+// TestGet_PendingRow_TreatedAsNotFound verifies that a storage record with
+// status=pending is rejected by getStorageAndCheckAccess with a 404.
+func TestGet_PendingRow_TreatedAsNotFound(t *testing.T) {
+	// given
+	backend := newMockBackend()
+	repo := newMockStorageRepo()
+	repo.records["file-pending"] = &Storage{
+		ID:                "file-pending",
+		UploaderPublicKey: "user-pk-1",
+		Filename:          "upload.jpg",
+		ContentType:       "image/jpeg",
+		SizeBytes:         512,
+		StoragePath:       "app-1/2026/05/file-pending.jpg",
+		CreatedAt:         time.Now().Unix(),
+		Status:            string(StorageStatusPending),
+	}
+
+	svc := &mockStorageService{repo: repo, backend: backend}
+	ep := newTestEndpointsStorage(svc, true)
+
+	ctx := newTestRequestCtxStorage("GET")
+	setStorageAuthUser(ctx, storageTestUser("user-pk-1"))
+	ctx.SetUserValue("storageID", "file-pending")
+
+	// when
+	ep.GetFile(ctx)
+
+	// then: pending row treated as not found before GetData is even called
+	assert.Equal(t, fasthttp.StatusNotFound, ctx.Response.StatusCode())
+}
+
+// TestCleanupPending_MockWiring verifies that the cleanup service plumbing calls
+// DeleteStalePending with the correct cutoff and that the mock repo honours the
+// stale/fresh split. NOTE: the SQL inside Repository.DeleteStalePending is NOT
+// exercised here; see the doc-comment on that method for the queries it runs.
+func TestCleanupPending_MockWiring(t *testing.T) {
+	// given
+	repo := newMockStorageRepo()
+	now := time.Now().Unix()
+
+	repo.records["stale-1"] = &Storage{
+		ID:        "stale-1",
+		Status:    string(StorageStatusPending),
+		CreatedAt: now - int64(2*time.Hour/time.Second),
+	}
+	repo.chunks["stale-1"] = []*StorageChunk{
+		{StorageID: "stale-1", ChunkIndex: 0},
+	}
+
+	repo.records["fresh-1"] = &Storage{
+		ID:        "fresh-1",
+		Status:    string(StorageStatusPending),
+		CreatedAt: now - int64(30*time.Minute/time.Second),
+	}
+
+	// when
+	err := runCleanupWithMockRepo(repo)
+
+	// then
+	assert.NoError(t, err)
+
+	repo.mu.Lock()
+	_, staleExists := repo.records["stale-1"]
+	_, freshExists := repo.records["fresh-1"]
+	_, staleChunksExist := repo.chunks["stale-1"]
+	repo.mu.Unlock()
+
+	assert.False(t, staleExists, "stale pending row must be deleted")
+	assert.True(t, freshExists, "fresh pending row must be kept")
+	assert.False(t, staleChunksExist, "chunks for stale row must be cleaned up")
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -2,8 +2,13 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"io"
 )
+
+// ErrBlobNotFound is returned by StorageBackend.Get when the blob does not exist
+// on the storage medium (e.g. file deleted from disk, S3 key missing).
+var ErrBlobNotFound = errors.New("blob not found")
 
 type StorageBackend interface {
 	Store(ctx context.Context, path string, reader io.Reader) error

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	_ "github.com/lib/pq"
 	"github.com/prappser/prappser-spaces/internal"
@@ -201,6 +202,10 @@ func main() {
 	storageService := storage.NewService(storageRepo, storageBackend, config.Storage.MaxFileSize)
 	storageEndpoints := storage.NewEndpoints(storageService, appRepository, eventService, userRepository, config.ExternalURL)
 	log.Info().Str("storageType", config.Storage.StorageType).Msg("Storage service initialized")
+
+	storagePendingCleanup := storage.NewPendingCleanupScheduler(storageService, 15*time.Minute)
+	storagePendingCleanup.Start()
+	log.Info().Msg("Storage pending upload cleanup scheduler started")
 
 	wsHandler := websocket.NewHandler(wsHub, userService)
 


### PR DESCRIPTION
…ng uploads

GetFile returns 404 (not 500) when the storage row exists but the blob is gone from disk, via a typed ErrBlobNotFound sentinel wrapped by both backends. getStorageAndCheckAccess also treats status != ready as 404, so abandoned chunked uploads never serve a stale path. Adds DeleteStalePending (transactional: chunks then rows) and a 15-min ticker that removes pending storage rows older than 1h, so failed InitChunkedUpload sequences stop leaking forever.

Closes the three server-side gaps behind the avatar-500 incident on ephemeral Railway disks.